### PR TITLE
Fix lyrics content saved as plain text

### DIFF
--- a/components/content-creator.tsx
+++ b/components/content-creator.tsx
@@ -86,7 +86,7 @@ export function ContentCreator({ onContentCreated }: ContentCreatorProps) {
       case "lyrics":
         content = {
           type: "Lyrics",
-          content: lyricsContent,
+          content: { lyrics: lyricsContent },
           title: "New Lyrics Sheet",
         }
         break

--- a/components/metadata-form.tsx
+++ b/components/metadata-form.tsx
@@ -155,6 +155,10 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
         is_favorite: !!metadata.isFavorite,
         is_public: !!metadata.isPublic,
       }
+
+      if (createdContent?.content) {
+        payload.content_data = createdContent.content
+      }
       console.log("Payload prepared:", payload)
 
       // Example: if you have files[0].url from uploads:


### PR DESCRIPTION
## Summary
- store lyrics inside a `lyrics` field when creating content
- include `content_data` in metadata form submissions so lyrics show in viewer

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684070e45d7c832999c724de4200a074