### PR TITLE
Fix duplicate listener issue in useToast

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure `useToast` hook does not re-register listeners on state updates

## Testing
- `npm run build`
- `npm run lint` *(fails: project not configured for Next.js ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68406f9605988329853fd80c18e694e0