### PR TITLE
Fix navigation route in AddContent

### DIFF
--- a/components/add-content.tsx
+++ b/components/add-content.tsx
@@ -247,7 +247,7 @@ export function AddContent({ onBack, onContentCreated, onNavigate }: AddContentP
             <div className="flex justify-center space-x-3">
               <Button
                 variant="outline"
-                onClick={() => onNavigate("add-content ")}
+                onClick={() => onNavigate("add-content")}
                 className="border-amber-300 text-amber-700 hover:bg-amber-50 px-4 py-2 text-sm"
               >
                 Add More Content


### PR DESCRIPTION
## Summary
- correct routing path used by the "Add More Content" button

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684079e8dd7483299136ff1126c8a8fd