### PR TITLE
Add Vitest setup and cn() tests

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from '../utils'
+
+describe('cn', () => {
+  it('merges class names correctly', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+    expect(cn('foo', false && 'bar')).toBe('foo')
+    expect(cn('foo', undefined, 'bar')).toBe('foo bar')
+    expect(cn('foo', 'foo', 'bar')).toBe('foo foo bar')
+    expect(cn('px-2', 'px-4')).toBe('px-4')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -69,6 +70,7 @@
     "eslint-config-next": "^15.3.3",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.2"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- configure Vitest as the test runner
- add a test script in package.json
- create a unit test for `cn()`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841f44d06888329b772c5e581dfdbaf