### PR TITLE
Fix capo ordinal display

### DIFF
--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -54,6 +54,15 @@ export function ContentViewer({ content, onBack, onEnterPerformance, onEdit }: C
   const [deleteDialog, setDeleteDialog] = useState(false)
   const [isFavorite, setIsFavorite] = useState(content?.is_favorite || false)
 
+  const getOrdinalSuffix = (num: number) => {
+    const mod10 = num % 10
+    const mod100 = num % 100
+    if (mod10 === 1 && mod100 !== 11) return "st"
+    if (mod10 === 2 && mod100 !== 12) return "nd"
+    if (mod10 === 3 && mod100 !== 13) return "rd"
+    return "th"
+  }
+
   const handleDelete = () => {
     setDeleteDialog(true)
   }
@@ -306,7 +315,7 @@ export function ContentViewer({ content, onBack, onEnterPerformance, onEdit }: C
                                 <div>
                                   <strong>Capo:</strong>{" "}
                                   {content.capo
-                                    ? `${content.capo}${content.capo === 1 ? "st" : content.capo === 2 ? "nd" : content.capo === 3 ? "rd" : "th"} fret`
+                                    ? `${content.capo}${getOrdinalSuffix(Number(content.capo))} fret`
                                     : "None"}
                                 </div>
                                 <div>


### PR DESCRIPTION
## Summary
- show capo fret with correct ordinal suffix
- add `getOrdinalSuffix` helper for consistent display

## Testing
- `npm run lint`
- manual inspection with Node to verify `getOrdinalSuffix` output

------
https://chatgpt.com/codex/tasks/task_e_6841f45877a8832993f13743737c33e6