### PR TITLE
Add vitest unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ We welcome contributions! Here's how you can help:
 4. **Documentation**: Help improve guides and documentation
 5. **Testing**: Test new features and provide feedback
 
+## 🧪 Tests
+
+Automated unit tests live in `lib/__tests__` and are executed with [Vitest](https://vitest.dev). Run `npm test` to execute them.
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/lib/__tests__/content-service.test.ts
+++ b/lib/__tests__/content-service.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+
+it('returns mock content when Supabase is not configured', async () => {
+  vi.doMock('../supabase', () => ({
+    isSupabaseConfigured: false,
+    getSupabaseBrowserClient: vi.fn(),
+  }))
+  const { getUserContent } = await import('../content-service')
+  const result = await getUserContent()
+  expect(Array.isArray(result)).toBe(true)
+  expect(result.length).toBeGreaterThan(0)
+  expect(result[0].id).toBe('mock-1')
+  vi.resetModules()
+})
+
+it('returns empty array when user not authenticated', async () => {
+  const mockClient = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null })
+    },
+    from: vi.fn()
+  }
+  vi.doMock('../supabase', () => ({
+    isSupabaseConfigured: true,
+    getSupabaseBrowserClient: () => mockClient,
+  }))
+  const { getUserContent } = await import('../content-service')
+  const data = await getUserContent()
+  expect(data).toEqual([])
+  vi.resetModules()
+})

--- a/lib/__tests__/setlist-service.test.ts
+++ b/lib/__tests__/setlist-service.test.ts
@@ -1,0 +1,29 @@
+import { it, expect, vi } from 'vitest'
+
+it('creates a mock setlist when Supabase is not configured', async () => {
+  vi.doMock('../supabase', () => ({
+    isSupabaseConfigured: false,
+    getSupabaseBrowserClient: vi.fn(),
+  }))
+  const { createSetlist } = await import('../setlist-service')
+  const result = await createSetlist({ name: 'Demo' })
+  expect(result.user_id).toBe('demo-user')
+  expect(result.setlist_songs).toEqual([])
+  vi.resetModules()
+})
+
+it('throws when Supabase is configured but user is missing', async () => {
+  const mockClient = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null })
+    },
+    from: vi.fn()
+  }
+  vi.doMock('../supabase', () => ({
+    isSupabaseConfigured: true,
+    getSupabaseBrowserClient: () => mockClient,
+  }))
+  const { createSetlist } = await import('../setlist-service')
+  await expect(createSetlist({ name: 'Demo' })).rejects.toThrow('User not authenticated')
+  vi.resetModules()
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@edge-runtime/vm": "latest",
@@ -72,6 +73,8 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "eslint": "^9.28.0",
+    "eslint-config-next": "^15.3.3",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
   test: {
     environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './'),
+    },
   },
 })


### PR DESCRIPTION
## Summary
- add tests for content- and setlist-service
- configure alias for vitest
- expose `test` npm script
- document tests in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68470e784c0883299b560242d5923412