### PR TITLE
Ensure consistent music text formatting

### DIFF
--- a/components/chord-editor.tsx
+++ b/components/chord-editor.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Plus, Trash2, GripVertical } from "lucide-react"
+import { MusicText } from "@/components/music-text"
 
 interface ChordEditorProps {
   content: any
@@ -196,7 +197,7 @@ export function ChordEditor({ content, onChange }: ChordEditorProps) {
                     placeholder="Enter lyrics for this section..."
                     value={section.lyrics}
                     onChange={(e) => updateSection(section.id, "lyrics", e.target.value)}
-                    className="min-h-[100px]"
+                    className="min-h-[100px] font-mono"
                   />
                 </div>
               </div>
@@ -227,7 +228,9 @@ export function ChordEditor({ content, onChange }: ChordEditorProps) {
                 <div key={section.id}>
                   {section.name && <h3 className="font-bold text-blue-600 mb-2">{section.name}:</h3>}
                   {section.chords && <p className="font-mono bg-gray-100 p-2 rounded mb-2">Chords: {section.chords}</p>}
-                  {section.lyrics && <p className="whitespace-pre-line">{section.lyrics}</p>}
+                  {section.lyrics && (
+                    <MusicText text={section.lyrics} monospace={false} />
+                  )}
                 </div>
               ))}
             </div>

--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -36,6 +36,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { deleteContent } from "@/lib/content-service"
+import { MusicText } from "@/components/music-text"
 import Image from "next/image"
 
 interface ContentViewerProps {
@@ -417,9 +418,10 @@ export function ContentViewer({ content, onBack, onEnterPerformance, onEdit }: C
                                 </div>
                               ) : content.content_data?.notation ? (
                                 <div className="bg-gray-50 p-6 border rounded-lg">
-                                  <pre className="whitespace-pre-wrap text-sm font-mono leading-relaxed">
-                                    {content.content_data.notation}
-                                  </pre>
+                                  <MusicText
+                                    text={content.content_data.notation}
+                                    className="text-sm leading-relaxed"
+                                  />
                                 </div>
                               ) : (
                                 <div className="border-2 border-dashed border-gray-300 rounded-lg p-12 text-center">
@@ -476,9 +478,10 @@ export function ContentViewer({ content, onBack, onEnterPerformance, onEdit }: C
 
                               {content.content_data?.lyrics ? (
                                 <div className="space-y-6">
-                                  <pre className="bg-gray-50 p-4 rounded-lg whitespace-pre-wrap text-sm leading-relaxed font-sans">
-                                    {content.content_data.lyrics}
-                                  </pre>
+                                  <MusicText
+                                    text={content.content_data.lyrics}
+                                    className="bg-gray-50 p-4 rounded-lg text-sm leading-relaxed"
+                                  />
                                 </div>
                               ) : (
                                 <div className="bg-gray-50 p-8 rounded-lg text-center">
@@ -510,9 +513,11 @@ export function ContentViewer({ content, onBack, onEnterPerformance, onEdit }: C
                                 <span className="mr-2">📝</span>
                                 Performance Notes
                               </h4>
-                              <div className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
-                                {content.notes}
-                              </div>
+                              <MusicText
+                                text={content.notes}
+                                monospace={false}
+                                className="text-sm text-gray-700"
+                              />
                             </div>
                           )}
 
@@ -597,7 +602,11 @@ export function ContentViewer({ content, onBack, onEnterPerformance, onEdit }: C
                     <h3 className="text-lg font-semibold mb-4 text-green-800">Performance Notes</h3>
                     {content.notes ? (
                       <div className="bg-green-50 p-4 rounded-lg">
-                        <pre className="whitespace-pre-wrap text-sm text-gray-700 leading-relaxed">{content.notes}</pre>
+                        <MusicText
+                          text={content.notes}
+                          monospace={false}
+                          className="text-sm text-gray-700"
+                        />
                       </div>
                     ) : (
                       <div className="text-center py-8">

--- a/components/music-text.tsx
+++ b/components/music-text.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import React from "react"
+import { cn } from "@/lib/utils"
+
+interface MusicTextProps {
+  text: string
+  className?: string
+  monospace?: boolean
+}
+
+// very small markdown parser for **bold** and *italic* or __bold__ and _italic_
+function parseMarkdown(text: string): string {
+  const escapeHtml = (str: string) =>
+    str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+
+  let html = escapeHtml(text)
+
+  // bold **text** or __text__
+  html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+  html = html.replace(/__(.+?)__/g, "<strong>$1</strong>")
+
+  // italic *text* or _text_
+  html = html.replace(/\*(.+?)\*/g, "<em>$1</em>")
+  html = html.replace(/_(.+?)_/g, "<em>$1</em>")
+
+  return html
+}
+
+export function MusicText({ text, className, monospace = true }: MusicTextProps) {
+  const html = parseMarkdown(text)
+  return (
+    <pre
+      className={cn("whitespace-pre-wrap", monospace && "font-mono", className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}

--- a/components/performance-mode.tsx
+++ b/components/performance-mode.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { MusicText } from "@/components/music-text"
 import {
   X,
   ChevronLeft,
@@ -48,20 +49,7 @@ export function PerformanceMode({
     ? [selectedContent]
     : defaultSetlist
 
-  const parseLyrics = (lyrics: string) =>
-    lyrics
-      .split("\n\n")
-      .map((section) => ({
-        title: "",
-        content: section.split("\n").map((line) => ({ text: line })),
-      }))
-
-  const lyricsData = songs.map((song: any) => {
-    if (song?.content_data?.lyrics) {
-      return { sections: parseLyrics(song.content_data.lyrics) }
-    }
-    return { sections: [] }
-  })
+  const lyricsData = songs.map((song: any) => song?.content_data?.lyrics || "")
 
   useEffect(() => {
     let interval: NodeJS.Timeout
@@ -192,17 +180,8 @@ export function PerformanceMode({
             </div>
 
             <div className="space-y-8 max-w-3xl mx-auto">
-              {lyricsData[currentSong]?.sections.length ? (
-                lyricsData[currentSong].sections.map((section, sectionIndex) => (
-                  <div key={sectionIndex} className="mb-8">
-                    {section.title && <h3 className="font-bold text-[#2E7CE4] text-xl mb-3">{section.title}</h3>}
-                    <div className="mb-4 text-lg leading-relaxed">
-                      {section.content.map((part: any, partIndex: number) => (
-                        <span key={partIndex}>{part.text}</span>
-                      ))}
-                    </div>
-                  </div>
-                ))
+              {lyricsData[currentSong] ? (
+                <MusicText text={lyricsData[currentSong]} className="text-lg leading-relaxed" />
               ) : (
                 <div className="text-center text-[#A69B8E] py-10">
                   <p className="text-xl">No lyrics available for this song</p>


### PR DESCRIPTION
## Summary
- add `MusicText` component for preformatted lyrics and chords
- render lyrics with `MusicText` in PerformanceMode
- use `MusicText` in library viewer and chord editor
- preserve spacing in chord editor's lyrics input

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68471831ffe88329ad61fe61ac9aecd4