### PR TITLE
Fix login redirect to dashboard

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -49,7 +49,7 @@ export default function LoginPage() {
                 (user.user_metadata.full_name || "").split(" ").slice(1).join(" ") || null,
               avatar_url: user.user_metadata.avatar_url || null,
             })
-            window.location.href = "/profile"
+            window.location.href = "/dashboard"
             return
           } catch (err) {
             console.error("Profile creation failed:", err)


### PR DESCRIPTION
## Summary
- redirect to dashboard after login instead of auto-opening profile page

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68497eb92d508329988d3eb970fb9eab