### PR TITLE
Add extensive tests for service modules and hooks

### DIFF
--- a/hooks/__tests__/use-toast.test.ts
+++ b/hooks/__tests__/use-toast.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { reducer } from '../use-toast'
+
+describe('toast reducer', () => {
+  it('adds toast and respects limit', () => {
+    const state = { toasts: [] as any[] }
+    const newState = reducer(state, {
+      type: 'ADD_TOAST',
+      toast: { id: '1', title: 'A' }
+    })
+    expect(newState.toasts.length).toBe(1)
+    const limitedState = reducer(newState, {
+      type: 'ADD_TOAST',
+      toast: { id: '2', title: 'B' }
+    })
+    expect(limitedState.toasts.length).toBe(1)
+    expect(limitedState.toasts[0].id).toBe('2')
+  })
+
+  it('updates toast', () => {
+    const state = { toasts: [{ id: '1', title: 'A' }] }
+    const updated = reducer(state, {
+      type: 'UPDATE_TOAST',
+      toast: { id: '1', title: 'B' }
+    })
+    expect(updated.toasts[0].title).toBe('B')
+  })
+
+  it('dismisses toast', () => {
+    const state = { toasts: [{ id: '1', open: true }, { id: '2', open: true }] }
+    const dismissed = reducer(state, {
+      type: 'DISMISS_TOAST',
+      toastId: '1'
+    })
+    expect(dismissed.toasts[0].open).toBe(false)
+    expect(dismissed.toasts[1].open).toBe(true)
+  })
+
+  it('removes toast', () => {
+    const state = { toasts: [{ id: '1' }, { id: '2' }] }
+    const removed = reducer(state, { type: 'REMOVE_TOAST', toastId: '1' })
+    expect(removed.toasts.length).toBe(1)
+    expect(removed.toasts[0].id).toBe('2')
+  })
+})

--- a/lib/__tests__/content-service-extended.test.ts
+++ b/lib/__tests__/content-service-extended.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+
+const demoMock = {
+  isSupabaseConfigured: false,
+  getSupabaseBrowserClient: vi.fn()
+}
+
+describe('content-service demo mode', () => {
+  it('createContent returns mock item', async () => {
+    vi.doMock('../supabase', () => demoMock)
+    const { createContent } = await import('../content-service')
+    const item = await createContent({ title: 'Test', artist: 'Me', content_type: 'Lyrics' } as any)
+    expect(item.id).toMatch(/^mock-/)
+    expect(item.user_id).toBe('demo-user')
+    vi.resetModules()
+  })
+
+  it('updateContent updates mock item', async () => {
+    vi.doMock('../supabase', () => demoMock)
+    const { updateContent } = await import('../content-service')
+    const updated = await updateContent('mock-1', { title: 'New' } as any)
+    expect(updated.title).toBe('New')
+    vi.resetModules()
+  })
+
+  it('deleteContent resolves to true in demo mode', async () => {
+    vi.doMock('../supabase', () => demoMock)
+    const { deleteContent } = await import('../content-service')
+    const res = await deleteContent('mock-1')
+    expect(res).toBe(true)
+    vi.resetModules()
+  })
+
+  it('getUserStats returns mocked counts', async () => {
+    vi.doMock('../supabase', () => demoMock)
+    const { getUserStats } = await import('../content-service')
+    const stats = await getUserStats()
+    expect(stats.totalContent).toBeGreaterThan(0)
+    expect(stats.favoriteContent).toBeGreaterThan(0)
+    vi.resetModules()
+  })
+})
+
+describe('content-service when configured but user missing', () => {
+  const mockClient = {
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }) },
+    from: vi.fn()
+  }
+
+  const configuredMock = {
+    isSupabaseConfigured: true,
+    getSupabaseBrowserClient: () => mockClient
+  }
+
+  it('updateContent throws when user not authenticated', async () => {
+    vi.doMock('../supabase', () => configuredMock)
+    const { updateContent } = await import('../content-service')
+    await expect(updateContent('1', { title: 'A' } as any)).rejects.toThrow('User not authenticated')
+    vi.resetModules()
+  })
+
+  it('getUserStats returns zeros when user not authenticated', async () => {
+    vi.doMock('../supabase', () => configuredMock)
+    const { getUserStats } = await import('../content-service')
+    const stats = await getUserStats()
+    expect(stats.totalContent).toBe(0)
+    expect(stats.favoriteContent).toBe(0)
+    vi.resetModules()
+  })
+})

--- a/lib/__tests__/setlist-service-extended.test.ts
+++ b/lib/__tests__/setlist-service-extended.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+
+describe('setlist-service demo mode', () => {
+  const demoMock = {
+    isSupabaseConfigured: false,
+    getSupabaseBrowserClient: vi.fn()
+  }
+
+  it('getUserSetlists returns mock data', async () => {
+    vi.doMock('../supabase', () => demoMock)
+    const { getUserSetlists } = await import('../setlist-service')
+    const lists = await getUserSetlists()
+    expect(Array.isArray(lists)).toBe(true)
+    expect(lists[0].id).toMatch(/^mock-setlist/)
+    vi.resetModules()
+  })
+
+  it('getSetlistById falls back to first item when id missing', async () => {
+    vi.doMock('../supabase', () => demoMock)
+    const { getSetlistById } = await import('../setlist-service')
+    const list = await getSetlistById('unknown')
+    expect(list.id).toBe('mock-setlist-1')
+    vi.resetModules()
+  })
+})

--- a/lib/__tests__/supabase.test.ts
+++ b/lib/__tests__/supabase.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+  vi.resetModules()
+})
+
+describe('supabase utils', () => {
+  it('isSupabaseConfigured false when env vars missing', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = ''
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = ''
+    const mod = await import('../supabase')
+    expect(mod.isSupabaseConfigured).toBe(false)
+  })
+
+  it('isSupabaseConfigured true with valid env', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://demo.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'a'.repeat(21)
+    const mod = await import('../supabase')
+    expect(mod.isSupabaseConfigured).toBe(true)
+  })
+
+  it('returns mock client when not configured', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = ''
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = ''
+    const mod = await import('../supabase')
+    const client = mod.getSupabaseBrowserClient()
+    expect(client.auth.signInWithPassword).toBeDefined()
+    const res = await client.auth.signInWithPassword()
+    expect(res.error.message).toMatch(/Demo mode/)
+  })
+
+  it('testSupabaseConnection returns false when not configured', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = ''
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = ''
+    const mod = await import('../supabase')
+    expect(await mod.testSupabaseConnection()).toBe(false)
+  })
+
+  it('testSupabaseConnection true when configured and query succeeds', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://demo.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'a'.repeat(21)
+    vi.doMock('@supabase/ssr', () => ({
+      createBrowserClient: () => ({
+        from: () => ({
+          select: () => ({ limit: () => Promise.resolve({ error: null }) })
+        })
+      })
+    }))
+    const mod = await import('../supabase')
+    expect(await mod.testSupabaseConnection()).toBe(true)
+    vi.resetModules()
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for supabase utilities
- expand coverage for content service
- expand coverage for setlist service
- test use-toast reducer

## Testing
- `npx vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_684ac807e2cc83298cf553742f693f4c