### PR TITLE
Fix toast hook effect dependencies

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent multiple listener registrations in `useToast` hooks by using an empty dependency array

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684ca0aa8d848329abd6ab01580c41e6