### PR TITLE
Fix state updates on unmounted pages

### DIFF
--- a/app/content/[id]/edit/page.tsx
+++ b/app/content/[id]/edit/page.tsx
@@ -18,24 +18,30 @@ export default function EditContentPage() {
   const [contentError, setContentError] = useState<string | null>(null)
 
   useEffect(() => {
+    let mounted = true
+
+    const loadContent = async (contentId: string) => {
+      try {
+        if (mounted) setContentLoading(true)
+        if (mounted) setContentError(null)
+        const data = await getContentById(contentId)
+        if (mounted) setContent(data)
+      } catch (err) {
+        console.error("Error loading content:", err)
+        if (mounted) setContentError("Failed to load content for editing.")
+      } finally {
+        if (mounted) setContentLoading(false)
+      }
+    }
+
     if (params.id && user) {
       loadContent(params.id as string)
     }
-  }, [params.id, user])
 
-  const loadContent = async (contentId: string) => {
-    try {
-      setContentLoading(true)
-      setContentError(null)
-      const data = await getContentById(contentId)
-      setContent(data)
-    } catch (err) {
-      console.error("Error loading content:", err)
-      setContentError("Failed to load content for editing.")
-    } finally {
-      setContentLoading(false)
+    return () => {
+      mounted = false
     }
-  }
+  }, [params.id, user])
 
   const handleSave = async (updatedContent: any) => {
     if (!content) return

--- a/app/content/[id]/page.tsx
+++ b/app/content/[id]/page.tsx
@@ -25,24 +25,33 @@ export default function ContentPage() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
 
   useEffect(() => {
+    let mounted = true
+
+    const loadContent = async (contentId: string) => {
+      try {
+        if (mounted) setContentLoading(true)
+        if (mounted) setContentError(null)
+        const data = await getContentById(contentId)
+        if (mounted) setContent(data)
+      } catch (err) {
+        console.error("Error loading content:", err)
+        if (mounted)
+          setContentError(
+            "Failed to load content. It may not exist or you don't have permission to view it.",
+          )
+      } finally {
+        if (mounted) setContentLoading(false)
+      }
+    }
+
     if (params.id && user) {
       loadContent(params.id as string)
     }
-  }, [params.id, user])
 
-  const loadContent = async (contentId: string) => {
-    try {
-      setContentLoading(true)
-      setContentError(null)
-      const data = await getContentById(contentId)
-      setContent(data)
-    } catch (err) {
-      console.error("Error loading content:", err)
-      setContentError("Failed to load content. It may not exist or you don't have permission to view it.")
-    } finally {
-      setContentLoading(false)
+    return () => {
+      mounted = false
     }
-  }
+  }, [params.id, user])
 
   // Handle navigation from sidebar
   const handleNavigate = (screen: string) => {

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -34,6 +34,7 @@ function PerformancePageInner() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    let mounted = true
     const contentId = params.get("contentId")
     const setlistId = params.get("setlistId")
 
@@ -41,7 +42,7 @@ function PerformancePageInner() {
       try {
         if (contentId) {
           const c = await getContentById(contentId)
-          setContent(c)
+          if (mounted) setContent(c)
         }
 
         if (setlistId) {
@@ -58,16 +59,20 @@ function PerformancePageInner() {
             sl.setlist_songs = songsWithContent
           }
 
-          setSetlist(sl)
+          if (mounted) setSetlist(sl)
         }
       } catch (err) {
         console.error("Failed to load performance data", err)
       } finally {
-        setLoading(false)
+        if (mounted) setLoading(false)
       }
     }
 
     load()
+
+    return () => {
+      mounted = false
+    }
   }, [params])
 
   // Handle exit performance mode


### PR DESCRIPTION
## Summary
- prevent state updates after unmount in performance page
- prevent state updates after unmount in content edit page
- prevent state updates after unmount in content view page

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684ca50d00d0832997517d0d2a67e959