### PR TITLE
Use dynamic imports for heavy components

### DIFF
--- a/app/add-content/page.tsx
+++ b/app/add-content/page.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { AddContent } from "@/components/add-content"
+import dynamic from "next/dynamic"
+
+const AddContent = dynamic(() => import("@/components/add-content"), {
+  loading: () => <p>Loading add content...</p>,
+})
 import { Sidebar } from "@/components/sidebar"
 import { useAuth } from "@/contexts/auth-context"
 import { cn } from "@/lib/utils"

--- a/app/content/[id]/edit/page.tsx
+++ b/app/content/[id]/edit/page.tsx
@@ -2,7 +2,11 @@
 
 import { useState, useEffect } from "react"
 import { useRouter, useParams } from "next/navigation"
-import { ContentEditor } from "@/components/content-editor"
+import dynamic from "next/dynamic"
+
+const ContentEditor = dynamic(() => import("@/components/content-editor"), {
+  loading: () => <p>Loading editor...</p>,
+})
 import { useAuth } from "@/contexts/auth-context"
 import { getContentById, updateContent } from "@/lib/content-service"
 import type { Database } from "@/types/supabase"

--- a/components/content-page-client.tsx
+++ b/components/content-page-client.tsx
@@ -4,7 +4,11 @@ import { useRouter } from "next/navigation";
 import type { Database } from "@/types/supabase";
 import { ContentViewer } from "@/components/content-viewer";
 import { Sidebar } from "@/components/sidebar";
-import { ContentEditor } from "@/components/content-editor";
+import dynamic from "next/dynamic";
+
+const ContentEditor = dynamic(() => import("@/components/content-editor"), {
+  loading: () => <p>Loading editor...</p>,
+});
 import { updateContent } from "@/lib/content-service";
 import { cn } from "@/lib/utils";
 

--- a/components/performance-page-client.tsx
+++ b/components/performance-page-client.tsx
@@ -1,6 +1,10 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { PerformanceMode } from "@/components/performance-mode";
+import dynamic from "next/dynamic";
+
+const PerformanceMode = dynamic(() => import("@/components/performance-mode"), {
+  loading: () => <p>Loading performance mode...</p>,
+});
 
 interface PerformancePageClientProps {
   content: any | null;


### PR DESCRIPTION
## Summary
- lazy load `AddContent` component
- lazy load `PerformanceMode` component
- lazy load `ContentEditor` component in two places

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684d7af63a4c8329926c0d3db67923d1