### PR TITLE
Enable static page caching

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+export const dynamic = "force-static"
+export const revalidate = 60
+
 import type React from "react"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+export const dynamic = "force-static"
+export const revalidate = 60
+
 export default function PrivacyPolicyPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-100 p-6">

--- a/app/signup/confirm-email/page.tsx
+++ b/app/signup/confirm-email/page.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+export const dynamic = "force-static"
+export const revalidate = 60
+
 import Link from "next/link"
 import { CheckCircle } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,19 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*.(?:png|jpg|jpeg|webp|svg|gif|ico|woff2?|ttf|eot|otf)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- mark static pages with a revalidate period and `force-static`
- set long-lived cache headers for assets in `public`

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684d7d4142a08329a99c59fd8615f8ba