### PR TITLE
Avoid repeated Supabase lookups in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -47,9 +47,28 @@ export async function middleware(request: NextRequest) {
     },
   )
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const userCookie = request.cookies.get("sb-user")?.value
+  let user
+
+  if (userCookie) {
+    try {
+      user = JSON.parse(userCookie)
+    } catch {
+      user = null
+    }
+  }
+
+  if (!user) {
+    const {
+      data: { user: fetchedUser },
+    } = await supabase.auth.getUser()
+    user = fetchedUser
+    if (user) {
+      response.cookies.set("sb-user", JSON.stringify(user), { path: "/" })
+    } else {
+      response.cookies.set("sb-user", "", { path: "/", maxAge: 0 })
+    }
+  }
 
   const protectedRoutes = ["/dashboard", "/library", "/setlists", "/settings", "/profile", "/add-content", "/content"]
   const isProtectedRoute = protectedRoutes.some((route) => request.nextUrl.pathname.startsWith(route))


### PR DESCRIPTION
## Summary
- cache the logged in user in a cookie so middleware only calls Supabase when missing

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_684d7d4cffe883298f342502f122a510