### PR TITLE
Add persistent header component

### DIFF
--- a/app/add-content/page.tsx
+++ b/app/add-content/page.tsx
@@ -8,6 +8,7 @@ const AddContent = dynamic(() => import("@/components/add-content"), {
   loading: () => <p>Loading add content...</p>,
 })
 import { Sidebar } from "@/components/sidebar"
+import { Header } from "@/components/header"
 import { useAuth } from "@/contexts/auth-context"
 import { cn } from "@/lib/utils"
 
@@ -16,6 +17,7 @@ export default function AddContentPage() {
   const { user, isLoading } = useAuth()
   const [activeScreen, setActiveScreen] = useState("add-content")
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
 
   // Handle navigation from sidebar
   const handleNavigate = (screen: string) => {
@@ -55,15 +57,24 @@ export default function AddContentPage() {
 
   return (
     <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar activeScreen={activeScreen} onNavigate={handleNavigate} onCollapsedChange={setSidebarCollapsed} />
-      <main
-        className={cn(
-          "flex-1 overflow-auto transition-all duration-300 ease-in-out",
-          sidebarCollapsed ? "md:ml-20" : "md:ml-72",
-        )}
+      <Sidebar
+        activeScreen={activeScreen}
+        onNavigate={handleNavigate}
+        onCollapsedChange={setSidebarCollapsed}
+        mobileOpen={sidebarMobileOpen}
+        onMobileOpenChange={setSidebarMobileOpen}
+      />
+      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <AddContent onNavigate={handleNavigate} onContentCreated={handleContentCreated} onBack={() => router.back()} />
-      </main>
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Add Content" />
+        <main className="flex-1 overflow-auto">
+          <AddContent
+            onNavigate={handleNavigate}
+            onContentCreated={handleContentCreated}
+            onBack={() => router.back()}
+          />
+        </main>
+      </div>
     </div>
   )
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation"
 import { useEffect, useState } from "react"
 import { Skeleton } from "@/components/ui/skeleton"
 import ProfileForm from "@/components/ProfileForm"
+import { Header } from "@/components/header"
 
 export default function ProfilePage() {
   const { user, isLoading, isInitialized } = useAuth()
@@ -52,8 +53,11 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="flex h-screen bg-[#fffcf7]">
-      <ProfileForm />
+    <div className="flex flex-col min-h-screen bg-[#fffcf7]">
+      <Header title="Profile" />
+      <main className="flex-1 overflow-auto">
+        <ProfileForm />
+      </main>
     </div>
   )
 }

--- a/app/setlists/page.tsx
+++ b/app/setlists/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { SetlistManager } from "@/components/setlist-manager"
 import { Sidebar } from "@/components/sidebar"
+import { Header } from "@/components/header"
 import { useAuth } from "@/contexts/auth-context"
 import { cn } from "@/lib/utils"
 
@@ -12,6 +13,7 @@ export default function SetlistsPage() {
   const { user, isLoading } = useAuth()
   const [activeScreen, setActiveScreen] = useState("setlists")
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
 
   // Handle navigation from sidebar
   const handleNavigate = (screen: string) => {
@@ -50,15 +52,20 @@ export default function SetlistsPage() {
 
   return (
     <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar activeScreen={activeScreen} onNavigate={handleNavigate} onCollapsedChange={setSidebarCollapsed} />
-      <main
-        className={cn(
-          "flex-1 overflow-auto transition-all duration-300 ease-in-out",
-          sidebarCollapsed ? "md:ml-20" : "md:ml-72",
-        )}
+      <Sidebar
+        activeScreen={activeScreen}
+        onNavigate={handleNavigate}
+        onCollapsedChange={setSidebarCollapsed}
+        mobileOpen={sidebarMobileOpen}
+        onMobileOpenChange={setSidebarMobileOpen}
+      />
+      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <SetlistManager onEnterPerformance={handleStartPerformance} />
-      </main>
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Setlists" />
+        <main className="flex-1 overflow-auto">
+          <SetlistManager onEnterPerformance={handleStartPerformance} />
+        </main>
+      </div>
     </div>
   )
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { Settings } from "@/components/settings"
 import { Sidebar } from "@/components/sidebar"
+import { Header } from "@/components/header"
 import { useAuth } from "@/contexts/auth-context"
 import { cn } from "@/lib/utils"
 
@@ -12,6 +13,7 @@ export default function SettingsPage() {
   const { user, isLoading } = useAuth()
   const [activeScreen, setActiveScreen] = useState("settings")
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
 
   // Handle navigation from sidebar
   const handleNavigate = (screen: string) => {
@@ -41,15 +43,20 @@ export default function SettingsPage() {
 
   return (
     <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar activeScreen={activeScreen} onNavigate={handleNavigate} onCollapsedChange={setSidebarCollapsed} />
-      <main
-        className={cn(
-          "flex-1 overflow-auto transition-all duration-300 ease-in-out",
-          sidebarCollapsed ? "md:ml-20" : "md:ml-72",
-        )}
+      <Sidebar
+        activeScreen={activeScreen}
+        onNavigate={handleNavigate}
+        onCollapsedChange={setSidebarCollapsed}
+        mobileOpen={sidebarMobileOpen}
+        onMobileOpenChange={setSidebarMobileOpen}
+      />
+      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Settings />
-      </main>
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Settings" />
+        <main className="flex-1 overflow-auto">
+          <Settings />
+        </main>
+      </div>
     </div>
   )
 }

--- a/components/content-page-client.tsx
+++ b/components/content-page-client.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import type { Database } from "@/types/supabase";
 import { ContentViewer } from "@/components/content-viewer";
 import { Sidebar } from "@/components/sidebar";
+import { Header } from "@/components/header";
 import dynamic from "next/dynamic";
 
 const ContentEditor = dynamic(() => import("@/components/content-editor"), {
@@ -26,6 +27,7 @@ export default function ContentPageClient({
   const [isEditing, setIsEditing] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeScreen, setActiveScreen] = useState("library");
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
 
   const handleNavigate = (screen: string) => {
     router.push(`/${screen}`);
@@ -65,28 +67,29 @@ export default function ContentPageClient({
         activeScreen={activeScreen}
         onNavigate={handleNavigate}
         onCollapsedChange={setSidebarCollapsed}
+        mobileOpen={sidebarMobileOpen}
+        onMobileOpenChange={setSidebarMobileOpen}
       />
-      <main
-        className={cn(
-          "flex-1 overflow-auto transition-all duration-300 ease-in-out",
-          sidebarCollapsed ? "md:ml-20" : "md:ml-72",
-        )}
+      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        {isEditing ? (
-          <ContentEditor
-            content={content}
-            onSave={handleSaveEdit}
-            onCancel={handleCancelEdit}
-          />
-        ) : (
-          <ContentViewer
-            content={content}
-            onBack={handleBack}
-            onEnterPerformance={handleEnterPerformance}
-            onEdit={handleEdit}
-          />
-        )}
-      </main>
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} title={isEditing ? "Edit Content" : "View Content"} />
+        <main className="flex-1 overflow-auto">
+          {isEditing ? (
+            <ContentEditor
+              content={content}
+              onSave={handleSaveEdit}
+              onCancel={handleCancelEdit}
+            />
+          ) : (
+            <ContentViewer
+              content={content}
+              onBack={handleBack}
+              onEnterPerformance={handleEnterPerformance}
+              onEdit={handleEdit}
+            />
+          )}
+        </main>
+      </div>
     </div>
   );
 }

--- a/components/dashboard-page-client.tsx
+++ b/components/dashboard-page-client.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Dashboard, ContentItem, UserStats } from "@/components/dashboard";
 import { Sidebar } from "@/components/sidebar";
+import { Header } from "@/components/header";
 import { cn } from "@/lib/utils";
 
 interface DashboardPageClientProps {
@@ -19,6 +20,7 @@ export default function DashboardPageClient({
   const router = useRouter();
   const [activeScreen, setActiveScreen] = useState("dashboard");
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
 
   const handleNavigate = (screen: string) => {
     if (screen === "dashboard") {
@@ -42,22 +44,23 @@ export default function DashboardPageClient({
         activeScreen={activeScreen}
         onNavigate={handleNavigate}
         onCollapsedChange={setSidebarCollapsed}
+        mobileOpen={sidebarMobileOpen}
+        onMobileOpenChange={setSidebarMobileOpen}
       />
-      <main
-        className={cn(
-          "flex-1 overflow-auto transition-all duration-300 ease-in-out",
-          sidebarCollapsed ? "md:ml-20" : "md:ml-72",
-        )}
+      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Dashboard
-          onNavigate={handleNavigate}
-          onSelectContent={handleSelectContent}
-          onEnterPerformance={handleEnterPerformance}
-          recentContent={recentContent}
-          favoriteContent={favoriteContent}
-          stats={stats}
-        />
-      </main>
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Dashboard" />
+        <main className="flex-1 overflow-auto">
+          <Dashboard
+            onNavigate={handleNavigate}
+            onSelectContent={handleSelectContent}
+            onEnterPerformance={handleEnterPerformance}
+            recentContent={recentContent}
+            favoriteContent={favoriteContent}
+            stats={stats}
+          />
+        </main>
+      </div>
     </div>
   );
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import Image from "next/image"
+import { Menu } from "lucide-react"
+import { UserHeader } from "@/components/user-header"
+
+interface HeaderProps {
+  onMenuClick?: () => void
+  title?: string
+}
+
+export function Header({ onMenuClick, title }: HeaderProps) {
+  return (
+    <header className="sticky top-0 z-40 w-full bg-white/80 backdrop-blur-sm border-b border-amber-200">
+      <div className="px-4 py-2 flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          {onMenuClick && (
+            <Button variant="ghost" size="icon" className="md:hidden" onClick={onMenuClick}>
+              <Menu className="h-5 w-5 text-amber-800" />
+            </Button>
+          )}
+          <div className="flex items-center space-x-2">
+            <Image src="/logos/octavia-icon.png" alt="Octavia" width={32} height={32} />
+            <Image
+              src="/logos/octavia-wordmark.png"
+              alt="Octavia"
+              width={120}
+              height={24}
+              className="hidden sm:block"
+            />
+          </div>
+          {title && <span className="ml-4 text-lg font-semibold text-amber-800 truncate">{title}</span>}
+        </div>
+        <UserHeader />
+      </div>
+    </header>
+  )
+}

--- a/components/library-page-client.tsx
+++ b/components/library-page-client.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Library } from "@/components/library";
 import { Sidebar } from "@/components/sidebar";
+import { Header } from "@/components/header";
 import { cn } from "@/lib/utils";
 
 interface LibraryPageClientProps {
@@ -15,6 +16,7 @@ export default function LibraryPageClient({
   const router = useRouter();
   const [activeScreen, setActiveScreen] = useState("library");
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
 
   const handleNavigate = (screen: string) => {
     router.push(`/${screen}`);
@@ -30,18 +32,16 @@ export default function LibraryPageClient({
         activeScreen={activeScreen}
         onNavigate={handleNavigate}
         onCollapsedChange={setSidebarCollapsed}
+        mobileOpen={sidebarMobileOpen}
+        onMobileOpenChange={setSidebarMobileOpen}
       />
-      <main
-        className={cn(
-          "flex-1 overflow-auto transition-all duration-300 ease-in-out",
-          sidebarCollapsed ? "md:ml-20" : "md:ml-72",
-        )}
+      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Library
-          onSelectContent={handleSelectContent}
-          initialContent={initialContent}
-        />
-      </main>
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Library" />
+        <main className="flex-1 overflow-auto">
+          <Library onSelectContent={handleSelectContent} initialContent={initialContent} />
+        </main>
+      </div>
     </div>
   );
 }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -15,7 +15,6 @@ import {
   Star,
   Clock,
   LogOut,
-  Menu,
   ChevronLeft,
   ChevronRight,
 } from "lucide-react"
@@ -30,12 +29,31 @@ interface SidebarProps {
   activeScreen: string
   onNavigate: (screen: string) => void
   onCollapsedChange?: (collapsed: boolean) => void
+  mobileOpen?: boolean
+  onMobileOpenChange?: (open: boolean) => void
 }
 
-export function Sidebar({ activeScreen, onNavigate, onCollapsedChange }: SidebarProps) {
+export function Sidebar({
+  activeScreen,
+  onNavigate,
+  onCollapsedChange,
+  mobileOpen: mobileOpenProp,
+  onMobileOpenChange,
+}: SidebarProps) {
   const { user, signOut } = useAuth()
   const [collapsed, setCollapsed] = useState(false)
-  const [mobileOpen, setMobileOpen] = useState(false)
+  const [internalMobileOpen, setInternalMobileOpen] = useState(false)
+  const isControlled = mobileOpenProp !== undefined
+  const mobileOpen = isControlled ? mobileOpenProp : internalMobileOpen
+
+  const setMobileOpen = (open: boolean) => {
+    if (!isControlled) {
+      setInternalMobileOpen(open)
+    }
+    if (onMobileOpenChange) {
+      onMobileOpenChange(open)
+    }
+  }
 
   // Notify parent component when collapsed state changes
   useEffect(() => {
@@ -70,21 +88,12 @@ export function Sidebar({ activeScreen, onNavigate, onCollapsedChange }: Sidebar
 
   return (
     <>
-      {/* Mobile Menu Button */}
-      <div className="fixed top-4 left-4 z-50 md:hidden">
-        <Button
-          variant="outline"
-          size="icon"
-          className="bg-white/80 backdrop-blur-sm border-amber-200 shadow-md"
-          onClick={() => setMobileOpen(!mobileOpen)}
-        >
-          <Menu className="h-5 w-5 text-amber-800" />
-        </Button>
-      </div>
-
       {/* Mobile Overlay */}
       {mobileOpen && (
-        <div className="fixed inset-0 bg-black/50 z-40 md:hidden" onClick={() => setMobileOpen(false)}></div>
+        <div
+          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          onClick={() => setMobileOpen(false)}
+        ></div>
       )}
 
       {/* Sidebar */}


### PR DESCRIPTION
## Summary
- create `Header` component with hamburger, logo and profile menu
- control sidebar mobile open from pages via new props
- render header across authenticated pages
- remove mobile menu button from sidebar

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test run cancelled. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_684dba99dfbc83298ba2c194cd52c44f