### PR TITLE
Remove redundant elements from sidebar and header

### DIFF
--- a/app/add-content/page.tsx
+++ b/app/add-content/page.tsx
@@ -66,7 +66,7 @@ export default function AddContentPage() {
       />
       <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Add Content" />
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
           <AddContent
             onNavigate={handleNavigate}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -54,7 +54,7 @@ export default function ProfilePage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-[#fffcf7]">
-      <Header title="Profile" />
+      <Header />
       <main className="flex-1 overflow-auto">
         <ProfileForm />
       </main>

--- a/app/setlists/page.tsx
+++ b/app/setlists/page.tsx
@@ -61,7 +61,7 @@ export default function SetlistsPage() {
       />
       <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Setlists" />
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
           <SetlistManager onEnterPerformance={handleStartPerformance} />
         </main>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -52,7 +52,7 @@ export default function SettingsPage() {
       />
       <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Settings" />
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
           <Settings />
         </main>

--- a/components/content-page-client.tsx
+++ b/components/content-page-client.tsx
@@ -76,10 +76,7 @@ export default function ContentPageClient({
           sidebarCollapsed ? "md:ml-20" : "md:ml-72",
         )}
       >
-        <Header
-          onMenuClick={() => setSidebarMobileOpen(true)}
-          title={isEditing ? "Edit Content" : "View Content"}
-        />
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
           {isEditing ? (
             <ContentEditor

--- a/components/dashboard-page-client.tsx
+++ b/components/dashboard-page-client.tsx
@@ -49,7 +49,7 @@ export default function DashboardPageClient({
       />
       <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Dashboard" />
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
           <Dashboard
             onNavigate={handleNavigate}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -7,10 +7,9 @@ import { UserHeader } from "@/components/user-header"
 
 interface HeaderProps {
   onMenuClick?: () => void
-  title?: string
 }
 
-export function Header({ onMenuClick, title }: HeaderProps) {
+export function Header({ onMenuClick }: HeaderProps) {
   return (
     <header className="sticky top-0 z-40 w-full bg-white/80 backdrop-blur-sm border-b border-amber-200">
       <div className="px-4 py-2 flex items-center justify-between">
@@ -30,7 +29,6 @@ export function Header({ onMenuClick, title }: HeaderProps) {
               className="hidden sm:block"
             />
           </div>
-          {title && <span className="ml-4 text-lg font-semibold text-amber-800 truncate">{title}</span>}
         </div>
         <UserHeader />
       </div>

--- a/components/library-page-client.tsx
+++ b/components/library-page-client.tsx
@@ -37,7 +37,7 @@ export default function LibraryPageClient({
       />
       <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
       >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} title="Library" />
+        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
           <Library onSelectContent={handleSelectContent} initialContent={initialContent} />
         </main>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -18,8 +18,6 @@ import {
   ChevronLeft,
   ChevronRight,
 } from "lucide-react"
-import { UserHeader } from "@/components/user-header"
-import Image from "next/image"
 import { useAuth } from "@/contexts/auth-context"
 import { useState, useEffect } from "react"
 import { cn } from "@/lib/utils"
@@ -105,36 +103,13 @@ export function Sidebar({
         )}
       >
         <div className="h-full flex flex-col bg-gradient-to-b from-amber-50 to-orange-50 border-r border-amber-200 shadow-lg overflow-hidden">
-          {/* Logo and Collapse Button */}
-          <div className="p-4 border-b border-amber-200 flex items-center justify-between">
-            <div
-              className={cn("flex items-center space-x-3 transition-opacity", collapsed ? "opacity-0" : "opacity-100")}
-            >
-              <Image src="/logos/octavia-icon.png" alt="Octavia" width={32} height={32} />
-              <Image src="/logos/octavia-wordmark.png" alt="Octavia" width={120} height={24} />
-            </div>
-            <div
-              className={cn(
-                "absolute left-1/2 transform -translate-x-1/2 transition-opacity",
-                collapsed ? "opacity-100" : "opacity-0",
-              )}
-            >
-              <Image src="/logos/octavia-icon.png" alt="Octavia" width={32} height={32} />
-            </div>
+          {/* Collapse Button */}
+          <div className="p-4 border-b border-amber-200 flex items-center justify-end">
             <Button variant="ghost" size="sm" className="text-amber-700 hover:bg-amber-100" onClick={toggleCollapsed}>
               {collapsed ? <ChevronRight className="h-5 w-5" /> : <ChevronLeft className="h-5 w-5" />}
             </Button>
           </div>
 
-          {/* User Profile */}
-          <div
-            className={cn(
-              "p-4 border-b border-amber-200 flex justify-center transition-all",
-              collapsed ? "opacity-70 hover:opacity-100" : "",
-            )}
-          >
-            <UserHeader compact={collapsed} />
-          </div>
 
           {/* Quick Actions */}
           <div className="p-4 space-y-2">


### PR DESCRIPTION
## Summary
- clean up sidebar, removing logo and user avatar
- drop page title prop from header component
- update all pages to use simplified header

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684dff4a60bc8329937aeea166aab17e