### PR TITLE
Update layout for full-width header

### DIFF
--- a/app/add-content/page.tsx
+++ b/app/add-content/page.tsx
@@ -56,18 +56,27 @@ export default function AddContentPage() {
   }
 
   return (
-    <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar
-        activeScreen={activeScreen}
-        onNavigate={handleNavigate}
-        onCollapsedChange={setSidebarCollapsed}
-        mobileOpen={sidebarMobileOpen}
-        onMobileOpenChange={setSidebarMobileOpen}
+    <div className="flex flex-col h-screen bg-[#fffcf7]">
+      <Header
+        onMenuClick={() => setSidebarMobileOpen(true)}
+        onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
+        collapsed={sidebarCollapsed}
       />
-      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
-      >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
-        <main className="flex-1 overflow-auto">
+      <div className="flex flex-1">
+        <Sidebar
+          activeScreen={activeScreen}
+          onNavigate={handleNavigate}
+          collapsed={sidebarCollapsed}
+          onCollapsedChange={setSidebarCollapsed}
+          mobileOpen={sidebarMobileOpen}
+          onMobileOpenChange={setSidebarMobileOpen}
+        />
+        <main
+          className={cn(
+            "flex-1 overflow-auto transition-all duration-300 ease-in-out",
+            sidebarCollapsed ? "md:ml-20" : "md:ml-72",
+          )}
+        >
           <AddContent
             onNavigate={handleNavigate}
             onContentCreated={handleContentCreated}

--- a/app/setlists/page.tsx
+++ b/app/setlists/page.tsx
@@ -51,18 +51,27 @@ export default function SetlistsPage() {
   }
 
   return (
-    <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar
-        activeScreen={activeScreen}
-        onNavigate={handleNavigate}
-        onCollapsedChange={setSidebarCollapsed}
-        mobileOpen={sidebarMobileOpen}
-        onMobileOpenChange={setSidebarMobileOpen}
+    <div className="flex flex-col h-screen bg-[#fffcf7]">
+      <Header
+        onMenuClick={() => setSidebarMobileOpen(true)}
+        onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
+        collapsed={sidebarCollapsed}
       />
-      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
-      >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
-        <main className="flex-1 overflow-auto">
+      <div className="flex flex-1">
+        <Sidebar
+          activeScreen={activeScreen}
+          onNavigate={handleNavigate}
+          collapsed={sidebarCollapsed}
+          onCollapsedChange={setSidebarCollapsed}
+          mobileOpen={sidebarMobileOpen}
+          onMobileOpenChange={setSidebarMobileOpen}
+        />
+        <main
+          className={cn(
+            "flex-1 overflow-auto transition-all duration-300 ease-in-out",
+            sidebarCollapsed ? "md:ml-20" : "md:ml-72",
+          )}
+        >
           <SetlistManager onEnterPerformance={handleStartPerformance} />
         </main>
       </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -42,18 +42,27 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar
-        activeScreen={activeScreen}
-        onNavigate={handleNavigate}
-        onCollapsedChange={setSidebarCollapsed}
-        mobileOpen={sidebarMobileOpen}
-        onMobileOpenChange={setSidebarMobileOpen}
+    <div className="flex flex-col h-screen bg-[#fffcf7]">
+      <Header
+        onMenuClick={() => setSidebarMobileOpen(true)}
+        onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
+        collapsed={sidebarCollapsed}
       />
-      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
-      >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
-        <main className="flex-1 overflow-auto">
+      <div className="flex flex-1">
+        <Sidebar
+          activeScreen={activeScreen}
+          onNavigate={handleNavigate}
+          collapsed={sidebarCollapsed}
+          onCollapsedChange={setSidebarCollapsed}
+          mobileOpen={sidebarMobileOpen}
+          onMobileOpenChange={setSidebarMobileOpen}
+        />
+        <main
+          className={cn(
+            "flex-1 overflow-auto transition-all duration-300 ease-in-out",
+            sidebarCollapsed ? "md:ml-20" : "md:ml-72",
+          )}
+        >
           <Settings />
         </main>
       </div>

--- a/components/content-page-client.tsx
+++ b/components/content-page-client.tsx
@@ -62,22 +62,27 @@ export default function ContentPageClient({
   };
 
   return (
-    <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar
-        activeScreen={activeScreen}
-        onNavigate={handleNavigate}
-        onCollapsedChange={setSidebarCollapsed}
-        mobileOpen={sidebarMobileOpen}
-        onMobileOpenChange={setSidebarMobileOpen}
+    <div className="flex flex-col h-screen bg-[#fffcf7]">
+      <Header
+        onMenuClick={() => setSidebarMobileOpen(true)}
+        onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
+        collapsed={sidebarCollapsed}
       />
-      <div
-        className={cn(
-          "flex-1 flex flex-col transition-all duration-300 ease-in-out",
-          sidebarCollapsed ? "md:ml-20" : "md:ml-72",
-        )}
-      >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
-        <main className="flex-1 overflow-auto">
+      <div className="flex flex-1">
+        <Sidebar
+          activeScreen={activeScreen}
+          onNavigate={handleNavigate}
+          collapsed={sidebarCollapsed}
+          onCollapsedChange={setSidebarCollapsed}
+          mobileOpen={sidebarMobileOpen}
+          onMobileOpenChange={setSidebarMobileOpen}
+        />
+        <main
+          className={cn(
+            "flex-1 overflow-auto transition-all duration-300 ease-in-out",
+            sidebarCollapsed ? "md:ml-20" : "md:ml-72",
+          )}
+        >
           {isEditing ? (
             <ContentEditor
               content={content}

--- a/components/dashboard-page-client.tsx
+++ b/components/dashboard-page-client.tsx
@@ -39,18 +39,27 @@ export default function DashboardPageClient({
   };
 
   return (
-    <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar
-        activeScreen={activeScreen}
-        onNavigate={handleNavigate}
-        onCollapsedChange={setSidebarCollapsed}
-        mobileOpen={sidebarMobileOpen}
-        onMobileOpenChange={setSidebarMobileOpen}
+    <div className="flex flex-col h-screen bg-[#fffcf7]">
+      <Header
+        onMenuClick={() => setSidebarMobileOpen(true)}
+        onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
+        collapsed={sidebarCollapsed}
       />
-      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
-      >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
-        <main className="flex-1 overflow-auto">
+      <div className="flex flex-1">
+        <Sidebar
+          activeScreen={activeScreen}
+          onNavigate={handleNavigate}
+          collapsed={sidebarCollapsed}
+          onCollapsedChange={setSidebarCollapsed}
+          mobileOpen={sidebarMobileOpen}
+          onMobileOpenChange={setSidebarMobileOpen}
+        />
+        <main
+          className={cn(
+            "flex-1 overflow-auto transition-all duration-300 ease-in-out",
+            sidebarCollapsed ? "md:ml-20" : "md:ml-72",
+          )}
+        >
           <Dashboard
             onNavigate={handleNavigate}
             onSelectContent={handleSelectContent}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,18 +2,34 @@
 
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
-import { Menu } from "lucide-react"
+import { Menu, PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { UserHeader } from "@/components/user-header"
 
 interface HeaderProps {
   onMenuClick?: () => void
+  onToggleCollapse?: () => void
+  collapsed?: boolean
 }
 
-export function Header({ onMenuClick }: HeaderProps) {
+export function Header({ onMenuClick, onToggleCollapse, collapsed }: HeaderProps) {
   return (
     <header className="sticky top-0 z-40 w-full bg-white/80 backdrop-blur-sm border-b border-amber-200">
       <div className="px-4 py-2 flex items-center justify-between">
         <div className="flex items-center space-x-3">
+          {onToggleCollapse && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="hidden md:inline-flex"
+              onClick={onToggleCollapse}
+            >
+              {collapsed ? (
+                <PanelLeftOpen className="h-5 w-5 text-amber-800" />
+              ) : (
+                <PanelLeftClose className="h-5 w-5 text-amber-800" />
+              )}
+            </Button>
+          )}
           {onMenuClick && (
             <Button variant="ghost" size="icon" className="md:hidden" onClick={onMenuClick}>
               <Menu className="h-5 w-5 text-amber-800" />

--- a/components/library-page-client.tsx
+++ b/components/library-page-client.tsx
@@ -27,18 +27,27 @@ export default function LibraryPageClient({
   };
 
   return (
-    <div className="flex h-screen bg-[#fffcf7]">
-      <Sidebar
-        activeScreen={activeScreen}
-        onNavigate={handleNavigate}
-        onCollapsedChange={setSidebarCollapsed}
-        mobileOpen={sidebarMobileOpen}
-        onMobileOpenChange={setSidebarMobileOpen}
+    <div className="flex flex-col h-screen bg-[#fffcf7]">
+      <Header
+        onMenuClick={() => setSidebarMobileOpen(true)}
+        onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
+        collapsed={sidebarCollapsed}
       />
-      <div className={cn("flex-1 flex flex-col transition-all duration-300 ease-in-out", sidebarCollapsed ? "md:ml-20" : "md:ml-72")}
-      >
-        <Header onMenuClick={() => setSidebarMobileOpen(true)} />
-        <main className="flex-1 overflow-auto">
+      <div className="flex flex-1">
+        <Sidebar
+          activeScreen={activeScreen}
+          onNavigate={handleNavigate}
+          collapsed={sidebarCollapsed}
+          onCollapsedChange={setSidebarCollapsed}
+          mobileOpen={sidebarMobileOpen}
+          onMobileOpenChange={setSidebarMobileOpen}
+        />
+        <main
+          className={cn(
+            "flex-1 overflow-auto transition-all duration-300 ease-in-out",
+            sidebarCollapsed ? "md:ml-20" : "md:ml-72",
+          )}
+        >
           <Library onSelectContent={handleSelectContent} initialContent={initialContent} />
         </main>
       </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -6,8 +6,6 @@ import {
   Library,
   Music,
   Settings,
-  Plus,
-  Search,
   Guitar,
   BookOpen,
   Mic,
@@ -15,17 +13,16 @@ import {
   Star,
   Clock,
   LogOut,
-  ChevronLeft,
-  ChevronRight,
 } from "lucide-react"
 import { useAuth } from "@/contexts/auth-context"
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { cn } from "@/lib/utils"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
 interface SidebarProps {
   activeScreen: string
   onNavigate: (screen: string) => void
+  collapsed?: boolean
   onCollapsedChange?: (collapsed: boolean) => void
   mobileOpen?: boolean
   onMobileOpenChange?: (open: boolean) => void
@@ -34,12 +31,13 @@ interface SidebarProps {
 export function Sidebar({
   activeScreen,
   onNavigate,
+  collapsed: collapsedProp,
   onCollapsedChange,
   mobileOpen: mobileOpenProp,
   onMobileOpenChange,
 }: SidebarProps) {
   const { user, signOut } = useAuth()
-  const [collapsed, setCollapsed] = useState(false)
+  const collapsed = collapsedProp ?? false
   const [internalMobileOpen, setInternalMobileOpen] = useState(false)
   const isControlled = mobileOpenProp !== undefined
   const mobileOpen = isControlled ? mobileOpenProp : internalMobileOpen
@@ -53,12 +51,7 @@ export function Sidebar({
     }
   }
 
-  // Notify parent component when collapsed state changes
-  useEffect(() => {
-    if (onCollapsedChange) {
-      onCollapsedChange(collapsed)
-    }
-  }, [collapsed, onCollapsedChange])
+
 
   const menuItems = [
     { id: "dashboard", label: "Dashboard", icon: Home, description: "Overview of your music" },
@@ -80,9 +73,6 @@ export function Sidebar({
     { id: "recent3", label: "Fly Me to the Moon", icon: Star },
   ]
 
-  const toggleCollapsed = () => {
-    setCollapsed(!collapsed)
-  }
 
   return (
     <>
@@ -97,58 +87,12 @@ export function Sidebar({
       {/* Sidebar */}
       <div
         className={cn(
-          "fixed left-0 top-0 h-full z-40 transition-all duration-300 ease-in-out",
+          "fixed left-0 top-14 h-[calc(100vh-3.5rem)] z-40 transition-all duration-300 ease-in-out",
           collapsed ? "w-20" : "w-72",
           mobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0",
         )}
       >
         <div className="h-full flex flex-col bg-gradient-to-b from-amber-50 to-orange-50 border-r border-amber-200 shadow-lg overflow-hidden">
-          {/* Collapse Button */}
-          <div className="p-4 border-b border-amber-200 flex items-center justify-end">
-            <Button variant="ghost" size="sm" className="text-amber-700 hover:bg-amber-100" onClick={toggleCollapsed}>
-              {collapsed ? <ChevronRight className="h-5 w-5" /> : <ChevronLeft className="h-5 w-5" />}
-            </Button>
-          </div>
-
-
-          {/* Quick Actions */}
-          <div className="p-4 space-y-2">
-            <TooltipProvider delayDuration={300}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    className={cn(
-                      "w-full justify-start bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-600 hover:to-orange-600 text-white shadow-md",
-                      collapsed && "justify-center px-0",
-                    )}
-                    size="sm"
-                    onClick={() => onNavigate("add-content")}
-                  >
-                    <Plus className="w-4 h-4 mr-2" />
-                    {!collapsed && <span>Add Content</span>}
-                  </Button>
-                </TooltipTrigger>
-                {collapsed && <TooltipContent side="right">Add Content</TooltipContent>}
-              </Tooltip>
-
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className={cn(
-                      "w-full justify-start border-amber-300 text-amber-800 hover:bg-amber-100",
-                      collapsed && "justify-center px-0",
-                    )}
-                    size="sm"
-                  >
-                    <Search className="w-4 h-4 mr-2" />
-                    {!collapsed && <span>Search</span>}
-                  </Button>
-                </TooltipTrigger>
-                {collapsed && <TooltipContent side="right">Search</TooltipContent>}
-              </Tooltip>
-            </TooltipProvider>
-          </div>
 
           {/* Navigation */}
           <nav className="flex-1 p-4 overflow-y-auto scrollbar-thin scrollbar-thumb-amber-300 scrollbar-track-transparent">


### PR DESCRIPTION
## Summary
- extend the header to span full width and include collapse toggle
- move sidebar toggle into header and remove actions from sidebar
- adjust sidebar position under the header
- update all pages to use the new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e04c1704c8329afe2e45b8db9972f