### PR TITLE
Restructure layout with fixed header

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,8 +2,10 @@
 
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
-import { Menu, PanelLeftClose, PanelLeftOpen } from "lucide-react"
+import { Menu, PanelLeftClose, PanelLeftOpen, Plus, Search } from "lucide-react"
 import { UserHeader } from "@/components/user-header"
+import Link from "next/link"
+import { Input } from "@/components/ui/input"
 
 interface HeaderProps {
   onMenuClick?: () => void
@@ -46,7 +48,23 @@ export function Header({ onMenuClick, onToggleCollapse, collapsed }: HeaderProps
             />
           </div>
         </div>
-        <UserHeader />
+        <div className="flex items-center space-x-3">
+          <Link href="/add-content">
+            <Button className="bg-gradient-to-r from-amber-500 to-orange-600 hover:from-amber-600 hover:to-orange-700 text-white">
+              <Plus className="w-4 h-4 mr-2" />
+              <span className="hidden sm:inline">Add Content</span>
+            </Button>
+          </Link>
+          <div className="relative hidden md:block">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
+            <Input
+              type="text"
+              placeholder="Search..."
+              className="pl-8 bg-white border-amber-200 focus:border-amber-400 focus:ring focus:ring-amber-200 focus:ring-opacity-50"
+            />
+          </div>
+          <UserHeader />
+        </div>
       </div>
     </header>
   )

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -12,9 +12,7 @@ import {
   List,
   Star,
   Clock,
-  LogOut,
 } from "lucide-react"
-import { useAuth } from "@/contexts/auth-context"
 import { useState } from "react"
 import { cn } from "@/lib/utils"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
@@ -36,7 +34,6 @@ export function Sidebar({
   mobileOpen: mobileOpenProp,
   onMobileOpenChange,
 }: SidebarProps) {
-  const { user, signOut } = useAuth()
   const collapsed = collapsedProp ?? false
   const [internalMobileOpen, setInternalMobileOpen] = useState(false)
   const isControlled = mobileOpenProp !== undefined
@@ -192,28 +189,6 @@ export function Sidebar({
             </div>
           </nav>
 
-          {/* Footer */}
-          <div className="p-4 border-t border-amber-200">
-            <TooltipProvider delayDuration={300}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    className={cn(
-                      "w-full justify-start text-amber-700 hover:bg-amber-100",
-                      collapsed && "justify-center px-0",
-                    )}
-                    size="sm"
-                    onClick={() => signOut()}
-                  >
-                    <LogOut className="w-4 h-4 mr-2" />
-                    {!collapsed && <span>Sign Out</span>}
-                  </Button>
-                </TooltipTrigger>
-                {collapsed && <TooltipContent side="right">Sign Out</TooltipContent>}
-              </Tooltip>
-            </TooltipProvider>
-          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- add search bar and global Add Content button to header
- simplify sidebar by removing sign-out section

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684e11425c14832999af8fa19a91418e