### PR TITLE
Fix header search to redirect to library

### DIFF
--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -3,7 +3,11 @@ import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { getUserContentServer } from "@/lib/content-service-server";
 import LibraryPageClient from "@/components/library-page-client";
 
-export default async function LibraryPage() {
+export default async function LibraryPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ [key: string]: string }>
+}) {
   const supabase = await getSupabaseServerClient();
   const {
     data: { user },
@@ -14,6 +18,8 @@ export default async function LibraryPage() {
   }
 
   const content = await getUserContentServer();
+  const resolved = await searchParams;
+  const search = resolved?.search || "";
 
-  return <LibraryPageClient initialContent={content} />;
+  return <LibraryPageClient initialContent={content} initialSearch={search} />;
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -5,14 +5,34 @@ import Image from "next/image"
 import { Menu, PanelLeftClose, PanelLeftOpen, Search } from "lucide-react"
 import { UserHeader } from "@/components/user-header"
 import { Input } from "@/components/ui/input"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
 
 interface HeaderProps {
   onMenuClick?: () => void
   onToggleCollapse?: () => void
   collapsed?: boolean
+  initialSearch?: string
 }
 
-export function Header({ onMenuClick, onToggleCollapse, collapsed }: HeaderProps) {
+export function Header({ onMenuClick, onToggleCollapse, collapsed, initialSearch }: HeaderProps) {
+  const router = useRouter()
+  const [query, setQuery] = useState(initialSearch || "")
+
+  useEffect(() => {
+    setQuery(initialSearch || "")
+  }, [initialSearch])
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const trimmed = query.trim()
+    if (trimmed) {
+      router.push(`/library?search=${encodeURIComponent(trimmed)}`)
+    } else {
+      router.push("/library")
+    }
+  }
+
   return (
     <header className="sticky top-0 z-40 w-full bg-white/80 backdrop-blur-sm border-b border-amber-200">
       <div className="px-4 py-2 flex items-center justify-between">
@@ -48,14 +68,16 @@ export function Header({ onMenuClick, onToggleCollapse, collapsed }: HeaderProps
           </div>
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative hidden md:block">
+          <form onSubmit={handleSubmit} className="relative w-32 sm:w-48 md:w-64">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={16} />
             <Input
               type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
               placeholder="Search..."
               className="pl-8 bg-white border-amber-200 focus:border-amber-400 focus:ring focus:ring-amber-200 focus:ring-opacity-50"
             />
-          </div>
+          </form>
           <UserHeader />
         </div>
       </div>

--- a/components/library-page-client.tsx
+++ b/components/library-page-client.tsx
@@ -7,11 +7,13 @@ import { Header } from "@/components/header";
 import { cn } from "@/lib/utils";
 
 interface LibraryPageClientProps {
-  initialContent: any[];
+  initialContent: any[]
+  initialSearch?: string
 }
 
 export default function LibraryPageClient({
   initialContent,
+  initialSearch,
 }: LibraryPageClientProps) {
   const router = useRouter();
   const [activeScreen, setActiveScreen] = useState("library");
@@ -32,6 +34,7 @@ export default function LibraryPageClient({
         onMenuClick={() => setSidebarMobileOpen(true)}
         onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
         collapsed={sidebarCollapsed}
+        initialSearch={initialSearch}
       />
       <div className="flex flex-1">
         <Sidebar
@@ -48,7 +51,11 @@ export default function LibraryPageClient({
             sidebarCollapsed ? "md:ml-20" : "md:ml-72",
           )}
         >
-          <Library onSelectContent={handleSelectContent} initialContent={initialContent} />
+          <Library
+            onSelectContent={handleSelectContent}
+            initialContent={initialContent}
+            initialSearch={initialSearch}
+          />
         </main>
       </div>
     </div>

--- a/components/library.tsx
+++ b/components/library.tsx
@@ -52,11 +52,12 @@ import {
 interface LibraryProps {
   onSelectContent: (content: any) => void;
   initialContent: any[];
+  initialSearch?: string;
 }
 
-export function Library({ onSelectContent, initialContent }: LibraryProps) {
+export function Library({ onSelectContent, initialContent, initialSearch }: LibraryProps) {
   const router = useRouter();
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(initialSearch || "");
   const [sortBy, setSortBy] = useState("recent");
   const [viewMode, setViewMode] = useState("grid");
   const [content, setContent] = useState<any[]>(initialContent);
@@ -69,6 +70,10 @@ export function Library({ onSelectContent, initialContent }: LibraryProps) {
   });
   const [deleteDialog, setDeleteDialog] = useState(false);
   const [contentToDelete, setContentToDelete] = useState<any>(null);
+
+  useEffect(() => {
+    setSearchQuery(initialSearch || "");
+  }, [initialSearch]);
 
   useEffect(() => {
     let filtered = [...content];


### PR DESCRIPTION
## Summary
- activate header search input and route to Library
- persist search term between header and Library
- allow Library page to read query param for search

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684ec0d3b5d08329b00d49afbce73de8