### PR TITLE
Move title field to creation step

### DIFF
--- a/components/content-creator.tsx
+++ b/components/content-creator.tsx
@@ -15,6 +15,7 @@ interface ContentCreatorProps {
 
 export function ContentCreator({ onContentCreated }: ContentCreatorProps) {
   const [activeType, setActiveType] = useState("lyrics")
+  const [lyricsTitle, setLyricsTitle] = useState("")
   const [lyricsContent, setLyricsContent] = useState("")
   const [chordChart, setChordChart] = useState({
     title: "",
@@ -84,24 +85,36 @@ export function ContentCreator({ onContentCreated }: ContentCreatorProps) {
     let content
     switch (activeType) {
       case "lyrics":
+        if (!lyricsTitle.trim()) {
+          alert("Title is required")
+          return
+        }
         content = {
           type: "Lyrics",
           content: { lyrics: lyricsContent },
-          title: "New Lyrics Sheet",
+          title: lyricsTitle.trim(),
         }
         break
       case "chords":
+        if (!chordChart.title.trim()) {
+          alert("Title is required")
+          return
+        }
         content = {
           type: "Chord Chart",
           content: chordChart,
-          title: chordChart.title || "New Chord Chart",
+          title: chordChart.title.trim(),
         }
         break
       case "tablature":
+        if (!tabContent.title.trim()) {
+          alert("Title is required")
+          return
+        }
         content = {
           type: "Guitar Tab",
           content: tabContent,
-          title: tabContent.title || "New Guitar Tab",
+          title: tabContent.title.trim(),
         }
         break
       default:
@@ -162,6 +175,15 @@ export function ContentCreator({ onContentCreated }: ContentCreatorProps) {
         <CardContent>
           {activeType === "lyrics" && (
             <div className="space-y-4">
+              <div>
+                <Label htmlFor="lyrics-title">Title</Label>
+                <Input
+                  id="lyrics-title"
+                  value={lyricsTitle}
+                  onChange={(e) => setLyricsTitle(e.target.value)}
+                  placeholder="Song title"
+                />
+              </div>
               <div>
                 <Label htmlFor="lyrics">Lyrics</Label>
                 <Textarea

--- a/components/metadata-form.tsx
+++ b/components/metadata-form.tsx
@@ -24,7 +24,6 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [metadata, setMetadata] = useState({
-    title: createdContent?.title || "",
     artist: "",
     album: "",
     genre: "",
@@ -131,17 +130,10 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
         return
       }
 
-      // Basic validation
-      if (!metadata.title) {
-        console.log("No title provided")
-        alert("Title is required!")
-        return
-      }
-
       // Build the insert payload
       const payload: any = {
         user_id: user.id,
-        title: metadata.title,
+        title: createdContent?.title || files?.[0]?.name || "Untitled",
         artist: metadata.artist || null,
         album: metadata.album || null,
         genre: metadata.genre || null,
@@ -249,16 +241,6 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
         <CardContent className="space-y-6">
           {/* Basic Information */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="title">Title *</Label>
-              <Input
-                id="title"
-                value={metadata.title}
-                onChange={(e) => setMetadata((prev) => ({ ...prev, title: e.target.value }))}
-                placeholder="Song title"
-                required
-              />
-            </div>
             <div>
               <Label htmlFor="artist">Artist</Label>
               <Input
@@ -437,7 +419,7 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
         </Button>
         <Button
           onClick={handleSubmit}
-          disabled={!metadata.title.trim() || isSubmitting}>
+          disabled={isSubmitting}>
           {isSubmitting ? "Saving..." : "Save Content"}
         </Button>
       </div>

--- a/components/simple-editor.tsx
+++ b/components/simple-editor.tsx
@@ -3,16 +3,20 @@
 import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 
 interface SimpleEditorProps {
   defaultValue?: string
   title?: string
-  onCreate: (text: string) => void
+  defaultTitle?: string
+  onCreate: (data: { title: string; text: string }) => void
 }
 
-export function SimpleEditor({ defaultValue = "", title, onCreate }: SimpleEditorProps) {
+export function SimpleEditor({ defaultValue = "", title, defaultTitle = "", onCreate }: SimpleEditorProps) {
   const [text, setText] = useState(defaultValue)
+  const [songTitle, setSongTitle] = useState(defaultTitle)
   const [preview, setPreview] = useState(false)
 
   return (
@@ -21,6 +25,15 @@ export function SimpleEditor({ defaultValue = "", title, onCreate }: SimpleEdito
         <CardTitle>{title || (preview ? "Preview" : "Edit Content")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        <div>
+          <Label htmlFor="content-title">Title</Label>
+          <Input
+            id="content-title"
+            value={songTitle}
+            onChange={(e) => setSongTitle(e.target.value)}
+            placeholder="Song title"
+          />
+        </div>
         {preview ? (
           <div className="whitespace-pre-wrap p-4 border rounded bg-white">
             {text}
@@ -37,7 +50,9 @@ export function SimpleEditor({ defaultValue = "", title, onCreate }: SimpleEdito
           <Button variant="outline" onClick={() => setPreview(!preview)}>
             Preview
           </Button>
-          <Button onClick={() => onCreate(text)}>Create Content</Button>
+          <Button onClick={() => songTitle.trim() && onCreate({ title: songTitle.trim(), text })} disabled={!songTitle.trim()}>
+            Create Content
+          </Button>
         </div>
       </CardContent>
     </Card>

--- a/components/text-import-preview.tsx
+++ b/components/text-import-preview.tsx
@@ -14,12 +14,12 @@ export function TextImportPreview({ files, onComplete, onBack }: TextImportPrevi
   const [index, setIndex] = useState(0)
   const [results, setResults] = useState<any[]>([])
 
-  const handleCreate = (text: string) => {
+  const handleCreate = ({ title, text }: { title: string; text: string }) => {
     const file = files[index]
     setResults((prev) => [
       ...prev,
       {
-        title: file.parsedTitle || file.name,
+        title,
         body: text,
         content_type: "Lyrics",
       },
@@ -29,7 +29,7 @@ export function TextImportPreview({ files, onComplete, onBack }: TextImportPrevi
     } else {
       onComplete(results.concat([
         {
-          title: file.parsedTitle || file.name,
+          title,
           body: text,
           content_type: "Lyrics",
         },
@@ -46,6 +46,7 @@ export function TextImportPreview({ files, onComplete, onBack }: TextImportPrevi
       <SimpleEditor
         title={`${file.name} (${index + 1}/${files.length})`}
         defaultValue={file.textBody || file.originalText || ""}
+        defaultTitle={file.parsedTitle || file.name}
         onCreate={handleCreate}
       />
       <div className="flex justify-between">


### PR DESCRIPTION
## Summary
- add title input to lyrics editor and validate all editors
- allow simple editor to collect a title
- carry title from text import preview into created content
- remove title from metadata form and use existing title when saving

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ecc0b7c10832986f4110b11b84a7f