### PR TITLE
Improve add details UX

### DIFF
--- a/components/metadata-form.tsx
+++ b/components/metadata-form.tsx
@@ -10,7 +10,14 @@ import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Music, Guitar, FileText, Star, Tag, Plus, X } from "lucide-react"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
 import { getSupabaseBrowserClient } from "@/lib/supabase"
+import { createContent } from "@/lib/content-service"
 
 
 interface MetadataFormProps {
@@ -180,6 +187,44 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
     }
   }
 
+  const handleSkip = async () => {
+    try {
+      setIsSubmitting(true)
+      if (createdContent?.id) {
+        onComplete(createdContent)
+        return
+      }
+
+      const supabase = getSupabaseBrowserClient()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      if (!user) {
+        alert("Not logged in. Please log in first.")
+        return
+      }
+
+      const payload: any = {
+        user_id: user.id,
+        title: createdContent?.title || files?.[0]?.name || "Untitled",
+        content_type: createdContent?.type || files?.[0]?.contentType || "unknown",
+        content_data: createdContent?.content || {},
+        file_url: files && files[0]?.url ? files[0].url : null,
+        is_favorite: false,
+        is_public: false,
+      }
+
+      const newContent = await createContent(payload)
+      onComplete(newContent)
+    } catch (error) {
+      console.error("Error skipping metadata:", error)
+      alert("Failed to save content. Please try again.")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   const getContentIcon = (type: string) => {
     switch (type) {
       case "Guitar Tab":
@@ -238,190 +283,203 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
           <CardTitle>Add Details</CardTitle>
           <p className="text-gray-600">Provide information to help organize and find your content</p>
         </CardHeader>
-        <CardContent className="space-y-6">
-          {/* Basic Information */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="artist">Artist</Label>
-              <Input
-                id="artist"
-                value={metadata.artist}
-                onChange={(e) => setMetadata((prev) => ({ ...prev, artist: e.target.value }))}
-                placeholder="Artist or composer"
-              />
-            </div>
-            <div>
-              <Label htmlFor="album">Album</Label>
-              <Input
-                id="album"
-                value={metadata.album}
-                onChange={(e) => setMetadata((prev) => ({ ...prev, album: e.target.value }))}
-                placeholder="Album or collection"
-              />
-            </div>
-            <div>
-              <Label htmlFor="genre">Genre</Label>
-              <Select
-                value={metadata.genre}
-                onValueChange={(value) => setMetadata((prev) => ({ ...prev, genre: value }))}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select genre" />
-                </SelectTrigger>
-                <SelectContent>
-                  {genres.map((genre) => (
-                    <SelectItem key={genre} value={genre}>
-                      {genre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {/* Musical Information */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div>
-              <Label htmlFor="key">Key</Label>
-              <Select value={metadata.key} onValueChange={(value) => setMetadata((prev) => ({ ...prev, key: value }))}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select key" />
-                </SelectTrigger>
-                <SelectContent>
-                  {keys.map((key) => (
-                    <SelectItem key={key} value={key}>
-                      {key}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label htmlFor="bpm">BPM</Label>
-              <Input
-                id="bpm"
-                type="number"
-                value={metadata.bpm}
-                onChange={(e) => setMetadata((prev) => ({ ...prev, bpm: e.target.value }))}
-                placeholder="120"
-              />
-            </div>
-            <div>
-              <Label htmlFor="timeSignature">Time Signature</Label>
-              <Select
-                value={metadata.timeSignature}
-                onValueChange={(value) => setMetadata((prev) => ({ ...prev, timeSignature: value }))}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="4/4">4/4</SelectItem>
-                  <SelectItem value="3/4">3/4</SelectItem>
-                  <SelectItem value="2/4">2/4</SelectItem>
-                  <SelectItem value="6/8">6/8</SelectItem>
-                  <SelectItem value="12/8">12/8</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label htmlFor="difficulty">Difficulty</Label>
-              <Select
-                value={metadata.difficulty}
-                onValueChange={(value) => setMetadata((prev) => ({ ...prev, difficulty: value }))}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select difficulty" />
-                </SelectTrigger>
-                <SelectContent>
-                  {difficulties.map((difficulty) => (
-                    <SelectItem key={difficulty} value={difficulty}>
-                      {difficulty}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {/* Tags */}
-          <div>
-            <Label>Tags</Label>
-            <div className="mt-2 space-y-3">
-              <div className="flex space-x-2">
-                <Input
-                  value={newTag}
-                  onChange={(e) => setNewTag(e.target.value)}
-                  placeholder="Add a tag"
-                  onKeyDown={(e) => e.key === "Enter" && addTag()}
-                />
-                <Button type="button" onClick={addTag} variant="outline">
-                  <Plus className="w-4 h-4" />
-                </Button>
-              </div>
-              {metadata.tags.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {metadata.tags.map((tag) => (
-                    <Badge key={tag} variant="secondary" className="flex items-center space-x-1">
-                      <Tag className="w-3 h-3" />
-                      <span>{tag}</span>
-                      <button type="button" onClick={() => removeTag(tag)} className="ml-1 hover:text-red-600">
-                        <X className="w-3 h-3" />
-                      </button>
-                    </Badge>
-                  ))}
+        <CardContent className="space-y-4">
+          <Accordion type="multiple" className="space-y-4">
+            <AccordionItem value="basic">
+              <AccordionTrigger className="text-left text-sm font-medium">Basic Info</AccordionTrigger>
+              <AccordionContent>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="artist">Artist</Label>
+                    <Input
+                      id="artist"
+                      value={metadata.artist}
+                      onChange={(e) => setMetadata((prev) => ({ ...prev, artist: e.target.value }))}
+                      placeholder="Artist or composer"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="album">Album</Label>
+                    <Input
+                      id="album"
+                      value={metadata.album}
+                      onChange={(e) => setMetadata((prev) => ({ ...prev, album: e.target.value }))}
+                      placeholder="Album or collection"
+                    />
+                  </div>
+                  <div className="md:col-span-2">
+                    <Label htmlFor="genre">Genre</Label>
+                    <Select
+                      value={metadata.genre}
+                      onValueChange={(value) => setMetadata((prev) => ({ ...prev, genre: value }))}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select genre" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {genres.map((genre) => (
+                          <SelectItem key={genre} value={genre}>
+                            {genre}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
-              )}
-            </div>
-          </div>
+              </AccordionContent>
+            </AccordionItem>
 
-          {/* Notes */}
-          <div>
-            <Label htmlFor="notes">Notes</Label>
-            <Textarea
-              id="notes"
-              value={metadata.notes}
-              onChange={(e) => setMetadata((prev) => ({ ...prev, notes: e.target.value }))}
-              placeholder="Add any notes about this content..."
-              className="min-h-[100px]"
-            />
-          </div>
+            <AccordionItem value="musical">
+              <AccordionTrigger className="text-left text-sm font-medium">Musical Info</AccordionTrigger>
+              <AccordionContent>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                  <div>
+                    <Label htmlFor="key">Key</Label>
+                    <Select value={metadata.key} onValueChange={(value) => setMetadata((prev) => ({ ...prev, key: value }))}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select key" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {keys.map((key) => (
+                          <SelectItem key={key} value={key}>
+                            {key}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="bpm">BPM</Label>
+                    <Input
+                      id="bpm"
+                      type="number"
+                      value={metadata.bpm}
+                      onChange={(e) => setMetadata((prev) => ({ ...prev, bpm: e.target.value }))}
+                      placeholder="120"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="timeSignature">Time Signature</Label>
+                    <Select
+                      value={metadata.timeSignature}
+                      onValueChange={(value) => setMetadata((prev) => ({ ...prev, timeSignature: value }))}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="4/4">4/4</SelectItem>
+                        <SelectItem value="3/4">3/4</SelectItem>
+                        <SelectItem value="2/4">2/4</SelectItem>
+                        <SelectItem value="6/8">6/8</SelectItem>
+                        <SelectItem value="12/8">12/8</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="difficulty">Difficulty</Label>
+                    <Select
+                      value={metadata.difficulty}
+                      onValueChange={(value) => setMetadata((prev) => ({ ...prev, difficulty: value }))}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select difficulty" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {difficulties.map((difficulty) => (
+                          <SelectItem key={difficulty} value={difficulty}>
+                            {difficulty}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
 
-          {/* Options */}
-          <div className="space-y-3">
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="favorite"
-                checked={metadata.isFavorite}
-                onCheckedChange={(checked) => setMetadata((prev) => ({ ...prev, isFavorite: !!checked }))}
-              />
-              <Label htmlFor="favorite" className="flex items-center space-x-2">
-                <Star className="w-4 h-4" />
-                <span>Add to favorites</span>
-              </Label>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="public"
-                checked={metadata.isPublic}
-                onCheckedChange={(checked) => setMetadata((prev) => ({ ...prev, isPublic: !!checked }))}
-              />
-              <Label htmlFor="public">Make this content public (shareable)</Label>
-            </div>
-          </div>
+            <AccordionItem value="organization">
+              <AccordionTrigger className="text-left text-sm font-medium">Organization</AccordionTrigger>
+              <AccordionContent>
+                <div className="space-y-6">
+                  <div>
+                    <Label>Tags</Label>
+                    <div className="mt-2 space-y-3">
+                      <div className="flex space-x-2">
+                        <Input
+                          value={newTag}
+                          onChange={(e) => setNewTag(e.target.value)}
+                          placeholder="Add a tag"
+                          onKeyDown={(e) => e.key === 'Enter' && addTag()}
+                        />
+                        <Button type="button" onClick={addTag} variant="outline">
+                          <Plus className="w-4 h-4" />
+                        </Button>
+                      </div>
+                      {metadata.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                          {metadata.tags.map((tag) => (
+                            <Badge key={tag} variant="secondary" className="flex items-center space-x-1">
+                              <Tag className="w-3 h-3" />
+                              <span>{tag}</span>
+                              <button type="button" onClick={() => removeTag(tag)} className="ml-1 hover:text-red-600">
+                                <X className="w-3 h-3" />
+                              </button>
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="notes">Notes</Label>
+                    <Textarea
+                      id="notes"
+                      value={metadata.notes}
+                      onChange={(e) => setMetadata((prev) => ({ ...prev, notes: e.target.value }))}
+                      placeholder="Add any notes about this content..."
+                      className="min-h-[100px]"
+                    />
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="favorite"
+                        checked={metadata.isFavorite}
+                        onCheckedChange={(checked) => setMetadata((prev) => ({ ...prev, isFavorite: !!checked }))}
+                      />
+                      <Label htmlFor="favorite" className="flex items-center space-x-2">
+                        <Star className="w-4 h-4" />
+                        <span>Add to favorites</span>
+                      </Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="public"
+                        checked={metadata.isPublic}
+                        onCheckedChange={(checked) => setMetadata((prev) => ({ ...prev, isPublic: !!checked }))}
+                      />
+                      <Label htmlFor="public">Make this content public (shareable)</Label>
+                    </div>
+                  </div>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         </CardContent>
       </Card>
 
       {/* Actions */}
-      <div className="flex justify-between">
-        <Button variant="outline" onClick={onBack}>
-          Back
-        </Button>
-        <Button
-          onClick={handleSubmit}
-          disabled={isSubmitting}>
-          {isSubmitting ? "Saving..." : "Save Content"}
-        </Button>
+      <div className="flex flex-col sm:flex-row justify-between gap-2">
+        <Button variant="outline" onClick={onBack}>Back</Button>
+        <div className="flex gap-2 justify-end">
+          <Button variant="ghost" onClick={handleSkip}>Skip</Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? "Saving..." : "Save Content"}
+          </Button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add accordion-based sectioning for optional metadata fields
- allow skipping the metadata step via new Skip button
- keep action buttons responsive

## Testing
- `pnpm lint`
- `pnpm test` *(fails: watch mode exited)*

------
https://chatgpt.com/codex/tasks/task_e_684ecf7cc4308329b2476653cb0dc8c7