### PR TITLE
Fix summary indicators on Add Details screen

### DIFF
--- a/components/metadata-form.tsx
+++ b/components/metadata-form.tsx
@@ -91,10 +91,16 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
   ].filter(Boolean).length
 
   const renderSummary = (completed: number, total: number) => {
-    if (completed === 0) return null
-    if (completed === total)
-      return <Check className="w-4 h-4 text-green-600" />
-    return <span className="text-xs text-gray-600">{`${completed} of ${total} completed`}</span>
+    const summary = `${completed} of ${total} completed`
+    if (completed === total) {
+      return (
+        <span className="flex items-center gap-1 text-xs text-gray-600 whitespace-nowrap">
+          <Check className="w-4 h-4 text-green-600" />
+          {summary}
+        </span>
+      )
+    }
+    return <span className="text-xs text-gray-600 whitespace-nowrap">{summary}</span>
   }
 
   const addTag = () => {


### PR DESCRIPTION
## Summary
- show completion summary even when nothing is filled
- display `x of y` values with optional checkmark for full sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed8b2274c8329b6ab475a62ba4bbd