### PR TITLE
Simplify content creation editor

### DIFF
--- a/components/content-creator.tsx
+++ b/components/content-creator.tsx
@@ -1,13 +1,12 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { FileText, Guitar, Music, Plus, Trash2, Eye } from "lucide-react"
+import { FileText, Music, Guitar, Plus } from "lucide-react"
 
 interface ContentCreatorProps {
   onContentCreated: (content: any) => void
@@ -15,117 +14,63 @@ interface ContentCreatorProps {
 
 export function ContentCreator({ onContentCreated }: ContentCreatorProps) {
   const [activeType, setActiveType] = useState("lyrics")
-  const [lyricsTitle, setLyricsTitle] = useState("")
-  const [lyricsContent, setLyricsContent] = useState("")
-  const [chordChart, setChordChart] = useState({
-    title: "",
-    artist: "",
-    key: "",
-    capo: "",
-    sections: [{ name: "Verse 1", chords: "Am F C G", lyrics: "" }],
-  })
-  const [tabContent, setTabContent] = useState({
-    title: "",
-    artist: "",
-    tuning: "Standard (EADGBE)",
-    capo: "",
-    tabs: [
-      "E|--0--3--0--2--0--|",
-      "B|--1--1--1--1--1--|",
-      "G|--0--0--0--0--0--|",
-      "D|--2--2--2--2--2--|",
-      "A|--3-------------|",
-      "E|----------------|",
+  const [title, setTitle] = useState("")
+  const [text, setText] = useState("")
+
+  useEffect(() => {
+    setText("")
+    setTitle("")
+  }, [activeType])
+
+  const placeholders: Record<string, string> = {
+    lyrics: "Write your lyrics here...",
+    chords: "Write your chord chart here...",
+    tablature: "Write your guitar tab here...",
+  }
+
+  const tips: Record<string, string[]> = {
+    lyrics: [
+      "Use blank lines to separate verses and choruses.",
+      "Add labels like [Verse], [Chorus], [Bridge] for better structure.",
     ],
-  })
+    chords: [
+      "Write chord progressions inline or above lyrics.",
+      "Align chords with lyrics using spacing or line breaks.",
+    ],
+    tablature: [
+      "Use numbers for fret positions.",
+      "Use dashes (-) or empty beats for rhythm.",
+      "Align notes vertically for chords.",
+      "Use | for measure separators.",
+    ],
+  }
+
+  const typeNames: Record<string, string> = {
+    lyrics: "Lyrics",
+    chords: "Chord Chart",
+    tablature: "Guitar Tab",
+  }
 
   const contentTypes = [
-    {
-      id: "lyrics",
-      name: "Lyrics Sheet",
-      icon: FileText,
-      description: "Create lyrics-only sheets",
-    },
-    {
-      id: "chords",
-      name: "Chord Chart",
-      icon: Music,
-      description: "Lyrics with chord progressions",
-    },
-    {
-      id: "tablature",
-      name: "Guitar Tablature",
-      icon: Guitar,
-      description: "Create simple guitar tabs",
-    },
+    { id: "lyrics", name: "Lyrics Sheet", icon: FileText, description: "Create lyrics-only sheets" },
+    { id: "chords", name: "Chord Chart", icon: Music, description: "Lyrics with chord progressions" },
+    { id: "tablature", name: "Guitar Tablature", icon: Guitar, description: "Create simple guitar tabs" },
   ]
 
-  const addChordSection = () => {
-    setChordChart((prev) => ({
-      ...prev,
-      sections: [...prev.sections, { name: "", chords: "", lyrics: "" }],
-    }))
-  }
-
-  const removeChordSection = (index: number) => {
-    setChordChart((prev) => ({
-      ...prev,
-      sections: prev.sections.filter((_, i) => i !== index),
-    }))
-  }
-
-  const updateChordSection = (index: number, field: string, value: string) => {
-    setChordChart((prev) => ({
-      ...prev,
-      sections: prev.sections.map((section, i) => (i === index ? { ...section, [field]: value } : section)),
-    }))
-  }
-
   const handleCreate = () => {
-    let content
-    switch (activeType) {
-      case "lyrics":
-        if (!lyricsTitle.trim()) {
-          alert("Title is required")
-          return
-        }
-        content = {
-          type: "Lyrics",
-          content: { lyrics: lyricsContent },
-          title: lyricsTitle.trim(),
-        }
-        break
-      case "chords":
-        if (!chordChart.title.trim()) {
-          alert("Title is required")
-          return
-        }
-        content = {
-          type: "Chord Chart",
-          content: chordChart,
-          title: chordChart.title.trim(),
-        }
-        break
-      case "tablature":
-        if (!tabContent.title.trim()) {
-          alert("Title is required")
-          return
-        }
-        content = {
-          type: "Guitar Tab",
-          content: tabContent,
-          title: tabContent.title.trim(),
-        }
-        break
-      default:
-        return
+    if (!title.trim()) {
+      alert("Title is required")
+      return
     }
-    onContentCreated(content)
+    onContentCreated({
+      type: typeNames[activeType],
+      content: { text },
+      title: title.trim(),
+    })
   }
 
   return (
     <div className="space-y-6">
-      {/* Content Type Selection */}
       <Card>
         <CardHeader>
           <CardTitle>Create New Content</CardTitle>
@@ -155,233 +100,38 @@ export function ContentCreator({ onContentCreated }: ContentCreatorProps) {
         </CardContent>
       </Card>
 
-      {/* Content Editor */}
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle>{contentTypes.find((t) => t.id === activeType)?.name} Editor</CardTitle>
-            <div className="flex space-x-2">
-              <Button variant="outline" size="sm">
-                <Eye className="w-4 h-4 mr-2" />
-                Preview
-              </Button>
-              <Button onClick={handleCreate}>
-                <Plus className="w-4 h-4 mr-2" />
-                Create Content
-              </Button>
-            </div>
-          </div>
+          <CardTitle>{contentTypes.find((t) => t.id === activeType)?.name} Editor</CardTitle>
         </CardHeader>
-        <CardContent>
-          {activeType === "lyrics" && (
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="lyrics-title">Title</Label>
-                <Input
-                  id="lyrics-title"
-                  value={lyricsTitle}
-                  onChange={(e) => setLyricsTitle(e.target.value)}
-                  placeholder="Song title"
-                />
-              </div>
-              <div>
-                <Label htmlFor="lyrics">Lyrics</Label>
-                <Textarea
-                  id="lyrics"
-                  placeholder="Enter your lyrics here..."
-                  value={lyricsContent}
-                  onChange={(e) => setLyricsContent(e.target.value)}
-                  className="min-h-[300px] font-mono"
-                />
-              </div>
-              <div className="text-sm text-gray-500">
-                <p>Tips:</p>
-                <ul className="list-disc list-inside space-y-1">
-                  <li>Use blank lines to separate verses and choruses</li>
-                  <li>Add [Verse], [Chorus], [Bridge] labels for structure</li>
-                  <li>Use consistent formatting for better readability</li>
-                </ul>
-              </div>
-            </div>
-          )}
-
-          {activeType === "chords" && (
-            <div className="space-y-6">
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div>
-                  <Label htmlFor="chord-title">Title</Label>
-                  <Input
-                    id="chord-title"
-                    value={chordChart.title}
-                    onChange={(e) => setChordChart((prev) => ({ ...prev, title: e.target.value }))}
-                    placeholder="Song title"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="chord-artist">Artist</Label>
-                  <Input
-                    id="chord-artist"
-                    value={chordChart.artist}
-                    onChange={(e) => setChordChart((prev) => ({ ...prev, artist: e.target.value }))}
-                    placeholder="Artist name"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="chord-key">Key</Label>
-                  <Select
-                    value={chordChart.key}
-                    onValueChange={(value) => setChordChart((prev) => ({ ...prev, key: value }))}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select key" className="bg-F2EDE5" />
-                    </SelectTrigger>
-                    <SelectContent className="bg-F2EDE5">
-                      {["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"].map((key) => (
-                        <SelectItem key={key} value={key}>
-                          {key}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label htmlFor="chord-capo">Capo</Label>
-                  <Input
-                    id="chord-capo"
-                    value={chordChart.capo}
-                    onChange={(e) => setChordChart((prev) => ({ ...prev, capo: e.target.value }))}
-                    placeholder="Fret number"
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <h4 className="font-medium">Song Sections</h4>
-                  <Button variant="outline" size="sm" onClick={addChordSection}>
-                    <Plus className="w-4 h-4 mr-2" />
-                    Add Section
-                  </Button>
-                </div>
-
-                {chordChart.sections.map((section, index) => (
-                  <Card key={index} className="p-4 bg-F2EDE5">
-                    <div className="space-y-3">
-                      <div className="flex items-center justify-between">
-                        <Input
-                          placeholder="Section name (e.g., Verse 1, Chorus)"
-                          value={section.name}
-                          onChange={(e) => updateChordSection(index, "name", e.target.value)}
-                          className="max-w-xs"
-                        />
-                        {chordChart.sections.length > 1 && (
-                          <Button variant="ghost" size="sm" onClick={() => removeChordSection(index)}>
-                            <Trash2 className="w-4 h-4" />
-                          </Button>
-                        )}
-                      </div>
-                      <div>
-                        <Label>Chord Progression</Label>
-                        <Input
-                          placeholder="Am F C G"
-                          value={section.chords}
-                          onChange={(e) => updateChordSection(index, "chords", e.target.value)}
-                        />
-                      </div>
-                      <div>
-                        <Label>Lyrics</Label>
-                        <Textarea
-                          placeholder="Enter lyrics for this section..."
-                          value={section.lyrics}
-                          onChange={(e) => updateChordSection(index, "lyrics", e.target.value)}
-                          className="min-h-[100px]"
-                        />
-                      </div>
-                    </div>
-                  </Card>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {activeType === "tablature" && (
-            <div className="space-y-6">
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div>
-                  <Label htmlFor="tab-title">Title</Label>
-                  <Input
-                    id="tab-title"
-                    value={tabContent.title}
-                    onChange={(e) => setTabContent((prev) => ({ ...prev, title: e.target.value }))}
-                    placeholder="Song title"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="tab-artist">Artist</Label>
-                  <Input
-                    id="tab-artist"
-                    value={tabContent.artist}
-                    onChange={(e) => setTabContent((prev) => ({ ...prev, artist: e.target.value }))}
-                    placeholder="Artist name"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="tab-tuning">Tuning</Label>
-                  <Select
-                    value={tabContent.tuning}
-                    onValueChange={(value) => setTabContent((prev) => ({ ...prev, tuning: value }))}
-                  >
-                    <SelectTrigger className="bg-F2EDE5">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="bg-F2EDE5">
-                      <SelectItem value="Standard (EADGBE)">Standard (EADGBE)</SelectItem>
-                      <SelectItem value="Drop D (DADGBE)">Drop D (DADGBE)</SelectItem>
-                      <SelectItem value="Open G (DGDGBD)">Open G (DGDGBD)</SelectItem>
-                      <SelectItem value="DADGAD">DADGAD</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label htmlFor="tab-capo">Capo</Label>
-                  <Input
-                    id="tab-capo"
-                    value={tabContent.capo}
-                    onChange={(e) => setTabContent((prev) => ({ ...prev, capo: e.target.value }))}
-                    placeholder="Fret number"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <Label>Tablature</Label>
-                <div className="mt-2 space-y-2">
-                  {tabContent.tabs.map((line, index) => (
-                    <Input
-                      key={index}
-                      value={line}
-                      onChange={(e) => {
-                        const newTabs = [...tabContent.tabs]
-                        newTabs[index] = e.target.value
-                        setTabContent((prev) => ({ ...prev, tabs: newTabs }))
-                      }}
-                      className="font-mono text-sm"
-                      placeholder={`${["E", "B", "G", "D", "A", "E"][index]}|`}
-                    />
-                  ))}
-                </div>
-                <div className="text-sm text-gray-500 mt-2">
-                  <p>Tips:</p>
-                  <ul className="list-disc list-inside space-y-1">
-                    <li>Use numbers for fret positions</li>
-                    <li>Use dashes (-) for empty beats</li>
-                    <li>Align notes vertically for chords</li>
-                    <li>Use | for measure separators</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          )}
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="content-title">Title</Label>
+            <Input
+              id="content-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Song title"
+            />
+          </div>
+          <Textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={12}
+            className="font-mono"
+            placeholder={placeholders[activeType]}
+          />
+          <div className="text-sm text-gray-500 space-y-1">
+            {tips[activeType].map((tip) => (
+              <p key={tip}>• {tip}</p>
+            ))}
+          </div>
+          <div>
+            <Button onClick={handleCreate}>
+              <Plus className="w-4 h-4 mr-2" />
+              Create Content
+            </Button>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/components/simple-editor.tsx
+++ b/components/simple-editor.tsx
@@ -11,18 +11,19 @@ interface SimpleEditorProps {
   defaultValue?: string
   title?: string
   defaultTitle?: string
+  placeholder?: string
+  tips?: string[]
   onCreate: (data: { title: string; text: string }) => void
 }
 
-export function SimpleEditor({ defaultValue = "", title, defaultTitle = "", onCreate }: SimpleEditorProps) {
+export function SimpleEditor({ defaultValue = "", title, defaultTitle = "", placeholder = "", tips = [], onCreate }: SimpleEditorProps) {
   const [text, setText] = useState(defaultValue)
   const [songTitle, setSongTitle] = useState(defaultTitle)
-  const [preview, setPreview] = useState(false)
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{title || (preview ? "Preview" : "Edit Content")}</CardTitle>
+        <CardTitle>{title || "Edit Content"}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div>
@@ -34,22 +35,21 @@ export function SimpleEditor({ defaultValue = "", title, defaultTitle = "", onCr
             placeholder="Song title"
           />
         </div>
-        {preview ? (
-          <div className="whitespace-pre-wrap p-4 border rounded bg-white">
-            {text}
+        <Textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={12}
+          className="font-mono"
+          placeholder={placeholder}
+        />
+        {tips.length > 0 && (
+          <div className="text-sm text-gray-500 space-y-1">
+            {tips.map((tip) => (
+              <p key={tip}>• {tip}</p>
+            ))}
           </div>
-        ) : (
-          <Textarea
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            rows={12}
-            className="font-mono"
-          />
         )}
-        <div className="flex space-x-2">
-          <Button variant="outline" onClick={() => setPreview(!preview)}>
-            Preview
-          </Button>
+        <div>
           <Button onClick={() => songTitle.trim() && onCreate({ title: songTitle.trim(), text })} disabled={!songTitle.trim()}>
             Create Content
           </Button>

--- a/components/text-import-preview.tsx
+++ b/components/text-import-preview.tsx
@@ -47,6 +47,11 @@ export function TextImportPreview({ files, onComplete, onBack }: TextImportPrevi
         title={`${file.name} (${index + 1}/${files.length})`}
         defaultValue={file.textBody || file.originalText || ""}
         defaultTitle={file.parsedTitle || file.name}
+        placeholder="Type your content here..."
+        tips={[
+          "Use blank lines to separate verses and choruses.",
+          "Add labels like [Verse], [Chorus], [Bridge] for better structure.",
+        ]}
         onCreate={handleCreate}
       />
       <div className="flex justify-between">


### PR DESCRIPTION
## Summary
- remove preview mode from simple editor
- simplify `ContentCreator` UI to a single textarea with guidance
- add placeholder and tip support to text import preview

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684eda53e314832996ca90f5fa490ecd