### PR TITLE
Improve import flow for docx files

### DIFF
--- a/components/add-content.tsx
+++ b/components/add-content.tsx
@@ -51,6 +51,19 @@ export function AddContent({
   const [contentType, setContentType] = useState("Lyrics Sheet");
   const [batchArtist, setBatchArtist] = useState("");
 
+  const importModes = [
+    {
+      id: "single",
+      name: "Single Content",
+      subtitle: "Import a file with a single song.",
+    },
+    {
+      id: "batch",
+      name: "Batch Import",
+      subtitle: "Import multiple songs from one file.",
+    },
+  ];
+
   const contentTypes = [
     { id: "lyrics", name: "Lyrics Sheet", icon: FileText },
     { id: "chords", name: "Chord Chart", icon: Music },
@@ -405,6 +418,11 @@ export function AddContent({
               </CardHeader>
               <CardContent className="p-4">
                 <FileUpload single onFilesUploaded={handleFilesUploaded} />
+                {uploadedFile && (
+                  <p className="text-center text-sm text-gray-600 mt-2">
+                    {uploadedFile.name}
+                  </p>
+                )}
               </CardContent>
             </Card>
 
@@ -434,25 +452,29 @@ export function AddContent({
                       );
                     })}
                   </div>
-                  <div className="flex items-center space-x-4">
+                  <div className="space-y-2">
                     <Label className="text-sm">Import Mode</Label>
-                    <div className="flex space-x-3 text-sm">
-                      <label className="flex items-center space-x-1">
-                        <input
-                          type="radio"
-                          checked={importMode === "single"}
-                          onChange={() => setImportMode("single")}
-                        />
-                        <span>Single Content</span>
-                      </label>
-                      <label className="flex items-center space-x-1">
-                        <input
-                          type="radio"
-                          checked={importMode === "batch"}
-                          onChange={() => setImportMode("batch")}
-                        />
-                        <span>Batch Import</span>
-                      </label>
+                    <div className="grid grid-cols-2 gap-2">
+                      {importModes.map((mode) => (
+                        <Card
+                          key={mode.id}
+                          onClick={() =>
+                            setImportMode(mode.id as "single" | "batch")
+                          }
+                          className={`cursor-pointer ${
+                            importMode === mode.id
+                              ? "ring-2 ring-primary"
+                              : "hover:shadow"
+                          }`}
+                        >
+                          <CardContent className="p-2 text-center space-y-1">
+                            <p className="text-sm font-medium">{mode.name}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {mode.subtitle}
+                            </p>
+                          </CardContent>
+                        </Card>
+                      ))}
                     </div>
                   </div>
                   {importMode === "batch" && (

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -29,10 +30,23 @@ export function FileUpload({
   const [isDragOver, setIsDragOver] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState<any[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const allowedExtensions = ["pdf", "docx", "txt"];
 
   const handleFiles = async (files: File[]) => {
     if (single) {
       files = files.slice(0, 1);
+    }
+    const unsupported = files.filter(
+      (f) =>
+        !allowedExtensions.some((ext) =>
+          f.name.toLowerCase().endsWith(`.${ext}`),
+        ),
+    );
+    if (unsupported.length > 0) {
+      toast.error(
+        `Unsupported file type: ${unsupported.map((f) => f.name).join(", ")}`,
+      );
+      files = files.filter((f) => !unsupported.includes(f));
     }
     setIsUploading(true);
 
@@ -134,6 +148,8 @@ export function FileUpload({
     switch (ext) {
       case "pdf":
         return "Sheet Music";
+      case "docx":
+        return "Document";
       case "gp5":
       case "gpx":
         return "Guitar Tab";
@@ -203,7 +219,7 @@ export function FileUpload({
         <input
           type="file"
           multiple={!single}
-          accept=".pdf,.png,.jpg,.jpeg,.gp5,.gpx,.txt,.mid,.midi,.xml,.musicxml"
+          accept=".pdf,.docx,.txt"
           onChange={handleFileSelect}
           className="hidden"
           id="file-upload"
@@ -214,7 +230,7 @@ export function FileUpload({
           </Button>
         </label>
         <p className="text-xs text-gray-500 mt-2">
-          Supports PDF, images, Guitar Pro, MIDI, MusicXML, and text files
+          Supports PDF, DOCX, and text files
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- allow docx files in the uploader and remove unsupported formats
- show filename after choosing a file
- add a modern card UI for selecting import mode
- warn on unsupported file types

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684f4882ef688329a2b689b031afa588