### PR TITLE
Fix batch import content mappings

### DIFF
--- a/components/batch-import.tsx
+++ b/components/batch-import.tsx
@@ -30,6 +30,12 @@ export function BatchImport({ onComplete }: BatchImportProps) {
   const [isImporting, setIsImporting] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
+  const keyMap: Record<string, string> = {
+    lyrics: "lyrics",
+    chord_chart: "chords",
+    tablature: "tablature",
+  }
+
   const handleFile = async (file: File) => {
     setFileName(file.name)
     setIsParsing(true)
@@ -60,10 +66,15 @@ export function BatchImport({ onComplete }: BatchImportProps) {
     try {
       const created = []
       for (const song of selected) {
+        const key = keyMap[type]
+        if (!key) {
+          toast.error("Invalid content type")
+          continue
+        }
         const item = await createContent({
           title: song.title,
           content_type: type,
-          content_data: { text: song.body.trim() },
+          content_data: { [key]: song.body.trim() },
         } as any)
         created.push(item)
       }

--- a/components/batch-preview.tsx
+++ b/components/batch-preview.tsx
@@ -32,6 +32,21 @@ export function BatchPreview({
   const [songs, setSongs] = useState<SongItem[]>(initialSongs);
   const [isImporting, setIsImporting] = useState(false);
 
+  const typeMap: Record<string, string> = {
+    "Lyrics Sheet": "lyrics",
+    "Chord Chart": "chord_chart",
+    "Guitar Tablature": "tablature",
+    lyrics: "lyrics",
+    chord_chart: "chord_chart",
+    tablature: "tablature",
+  };
+
+  const keyMap: Record<string, string> = {
+    lyrics: "lyrics",
+    chord_chart: "chords",
+    tablature: "tablature",
+  };
+
   const handleImport = async () => {
     const selected = songs.filter((s) => s.include);
     if (selected.length === 0) return;
@@ -39,11 +54,17 @@ export function BatchPreview({
     try {
       const created = [];
       for (const song of selected) {
+        const mappedType = typeMap[contentType];
+        if (!mappedType) {
+          toast.error("Invalid content type");
+          continue;
+        }
+        const key = keyMap[mappedType];
         const item = await createContent({
           title: song.title,
           artist: song.artist || null,
-          content_type: contentType,
-          content_data: { text: song.body.trim() },
+          content_type: mappedType,
+          content_data: { [key]: song.body.trim() },
         } as any);
         created.push(item);
       }


### PR DESCRIPTION
## Summary
- map batch import UI labels to backend content type IDs
- store imported content under lyrics/chords/tablature keys

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684fec8eab788329907974f1a8edac3d