### PR TITLE
Fix batch import content mapping

### DIFF
--- a/components/batch-import.tsx
+++ b/components/batch-import.tsx
@@ -30,10 +30,13 @@ export function BatchImport({ onComplete }: BatchImportProps) {
   const [isImporting, setIsImporting] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const keyMap: Record<string, string> = {
-    lyrics: "lyrics",
-    chord_chart: "chords",
-    tablature: "tablature",
+  const typeMap: Record<string, { type: string; key: string }> = {
+    lyrics: { type: "lyrics", key: "lyrics" },
+    chord_chart: { type: "chord_chart", key: "chords" },
+    tablature: { type: "tablature", key: "tablature" },
+    "Lyrics Sheet": { type: "lyrics", key: "lyrics" },
+    "Chord Chart": { type: "chord_chart", key: "chords" },
+    "Guitar Tablature": { type: "tablature", key: "tablature" },
   }
 
   const handleFile = async (file: File) => {
@@ -66,15 +69,15 @@ export function BatchImport({ onComplete }: BatchImportProps) {
     try {
       const created = []
       for (const song of selected) {
-        const key = keyMap[type]
-        if (!key) {
+        const mapping = typeMap[type]
+        if (!mapping) {
           toast.error("Invalid content type")
           continue
         }
         const item = await createContent({
           title: song.title,
-          content_type: type,
-          content_data: { [key]: song.body.trim() },
+          content_type: mapping.type,
+          content_data: { [mapping.key]: song.body.trim() },
         } as any)
         created.push(item)
       }

--- a/components/batch-preview.tsx
+++ b/components/batch-preview.tsx
@@ -32,19 +32,13 @@ export function BatchPreview({
   const [songs, setSongs] = useState<SongItem[]>(initialSongs);
   const [isImporting, setIsImporting] = useState(false);
 
-  const typeMap: Record<string, string> = {
-    "Lyrics Sheet": "lyrics",
-    "Chord Chart": "chord_chart",
-    "Guitar Tablature": "tablature",
-    lyrics: "lyrics",
-    chord_chart: "chord_chart",
-    tablature: "tablature",
-  };
-
-  const keyMap: Record<string, string> = {
-    lyrics: "lyrics",
-    chord_chart: "chords",
-    tablature: "tablature",
+  const typeMap: Record<string, { type: string; key: string }> = {
+    "Lyrics Sheet": { type: "lyrics", key: "lyrics" },
+    "Chord Chart": { type: "chord_chart", key: "chords" },
+    "Guitar Tablature": { type: "tablature", key: "tablature" },
+    lyrics: { type: "lyrics", key: "lyrics" },
+    chord_chart: { type: "chord_chart", key: "chords" },
+    tablature: { type: "tablature", key: "tablature" },
   };
 
   const handleImport = async () => {
@@ -54,17 +48,16 @@ export function BatchPreview({
     try {
       const created = [];
       for (const song of selected) {
-        const mappedType = typeMap[contentType];
-        if (!mappedType) {
+        const mapping = typeMap[contentType];
+        if (!mapping) {
           toast.error("Invalid content type");
           continue;
         }
-        const key = keyMap[mappedType];
         const item = await createContent({
           title: song.title,
           artist: song.artist || null,
-          content_type: mappedType,
-          content_data: { [key]: song.body.trim() },
+          content_type: mapping.type,
+          content_data: { [mapping.key]: song.body.trim() },
         } as any);
         created.push(item);
       }


### PR DESCRIPTION
## Summary
- ensure batch import uses correct JSON key for lyrics, chords, or tablature
- normalize content type names when importing multiple songs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ffc5b8db8832996bfdcd60ea842e7