### PR TITLE
Color-code content type selectors

### DIFF
--- a/components/add-content.tsx
+++ b/components/add-content.tsx
@@ -25,6 +25,7 @@ import { BatchPreview } from "@/components/batch-preview";
 import { createContent } from "@/lib/content-service";
 import { getSupabaseBrowserClient } from "@/lib/supabase";
 import { parseDocxFile, parsePdfFile, parseTextFile } from "@/lib/batch-import";
+import { getContentTypeStyle } from "@/lib/content-type-styles";
 
 interface AddContentProps {
   onBack: () => void;
@@ -390,14 +391,20 @@ export function AddContent({
               <div className="grid grid-cols-3 gap-2">
                 {contentTypes.map((type) => {
                   const Icon = type.icon;
+                  const styles = getContentTypeStyle(type.id);
+                  const selected = contentType === type.name;
                   return (
                     <Card
                       key={type.id}
                       onClick={() => setContentType(type.name)}
-                      className={`cursor-pointer ${contentType === type.name ? "ring-2 ring-primary" : "hover:shadow"}`}
+                      className={`cursor-pointer border ${styles.border} ${
+                        selected
+                          ? `ring-2 ${styles.ring} ${styles.bg}`
+                          : `hover:${styles.bg} hover:${styles.border}`
+                      }`}
                     >
                       <CardContent className="p-2 text-center space-y-1">
-                        <Icon className="w-6 h-6 mx-auto" />
+                        <Icon className={`w-6 h-6 mx-auto ${styles.icon}`} />
                         <p className="text-sm">{type.name}</p>
                       </CardContent>
                     </Card>

--- a/components/batch-import.tsx
+++ b/components/batch-import.tsx
@@ -17,6 +17,7 @@ import { parseDocxFile, parsePdfFile, ParsedSong } from "@/lib/batch-import"
 import { createContent } from "@/lib/content-service"
 import { toast } from "sonner"
 import { FileText, Music, Guitar, Upload } from "lucide-react"
+import { getContentTypeStyle } from "@/lib/content-type-styles"
 
 interface BatchImportProps {
   onComplete: (contents: any[]) => void
@@ -124,14 +125,20 @@ export function BatchImport({ onComplete }: BatchImportProps) {
           <div className="grid grid-cols-3 gap-2">
             {contentTypes.map((ct) => {
               const Icon = ct.icon
+              const styles = getContentTypeStyle(ct.id)
+              const selected = type === ct.id
               return (
                 <Card
                   key={ct.id}
                   onClick={() => setType(ct.id)}
-                  className={`cursor-pointer ${type === ct.id ? "ring-2 ring-primary" : "hover:shadow"}`}
+                  className={`cursor-pointer border ${styles.border} ${
+                    selected
+                      ? `ring-2 ${styles.ring} ${styles.bg}`
+                      : `hover:${styles.bg} hover:${styles.border}`
+                  }`}
                 >
                   <CardContent className="p-2 text-center space-y-1">
-                    <Icon className="w-6 h-6 mx-auto" />
+                    <Icon className={`w-6 h-6 mx-auto ${styles.icon}`} />
                     <p className="text-sm">{ct.name}</p>
                   </CardContent>
                 </Card>

--- a/components/content-creator.tsx
+++ b/components/content-creator.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { FileText, Music, Guitar, Plus } from "lucide-react"
+import { getContentTypeStyle } from "@/lib/content-type-styles"
 
 interface ContentCreatorProps {
   onContentCreated: (content: any) => void
@@ -92,16 +93,20 @@ export function ContentCreator({
             <div className="grid grid-cols-3 gap-2 md:gap-4">
               {contentTypes.map((type) => {
                 const Icon = type.icon
+                const styles = getContentTypeStyle(type.id)
+                const selected = activeType === type.id
                 return (
                   <Card
                     key={type.id}
-                    className={`cursor-pointer transition-all min-h-[44px] ${
-                      activeType === type.id ? "ring-2 ring-blue-500 bg-blue-50" : "hover:shadow-md"
+                    className={`cursor-pointer transition-all min-h-[44px] border ${styles.border} ${
+                      selected
+                        ? `ring-2 ${styles.ring} ${styles.bg}`
+                        : `hover:${styles.bg} hover:${styles.border}`
                     }`}
                     onClick={() => setActiveType(type.id)}
                   >
                     <CardContent className="p-2 md:p-4 text-center">
-                      <Icon className="w-6 h-6 md:w-8 md:h-8 mx-auto mb-2 md:mb-3 text-blue-600" />
+                      <Icon className={`w-6 h-6 md:w-8 md:h-8 mx-auto mb-2 md:mb-3 ${styles.icon}`} />
                       <h3 className="text-sm md:text-base font-medium text-gray-900">{type.name}</h3>
                       <p className="text-xs md:text-sm text-gray-600 mt-1">{type.description}</p>
                     </CardContent>

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -17,6 +17,7 @@ import {
   Check,
   AlertCircle,
 } from "lucide-react";
+import { getContentTypeStyle } from "@/lib/content-type-styles";
 
 interface FileUploadProps {
   onFilesUploaded: (files: any[]) => void;
@@ -167,11 +168,17 @@ export function FileUpload({
   };
 
   const getFileIcon = (contentType: string) => {
+    const styles = getContentTypeStyle(contentType);
     switch (contentType) {
       case "Guitar Tab":
-        return <Guitar className="w-5 h-5 text-orange-600" />;
+      case "Guitar Tablature":
+        return <Guitar className={`w-5 h-5 ${styles.icon}`} />;
+      case "Chord Chart":
+        return <Music className={`w-5 h-5 ${styles.icon}`} />;
       case "Sheet Music":
-        return <Music className="w-5 h-5 text-blue-600" />;
+        return <FileText className={`w-5 h-5 ${styles.icon}`} />;
+      case "Lyrics":
+        return <FileText className={`w-5 h-5 ${styles.icon}`} />;
       default:
         return <FileText className="w-5 h-5 text-gray-600" />;
     }

--- a/components/metadata-form.tsx
+++ b/components/metadata-form.tsx
@@ -22,6 +22,7 @@ import {
   Folder,
   Check,
 } from "lucide-react"
+import { getContentTypeStyle } from "@/lib/content-type-styles"
 import {
   Accordion,
   AccordionContent,
@@ -261,11 +262,17 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
   }
 
   const getContentIcon = (type: string) => {
+    const styles = getContentTypeStyle(type)
     switch (type) {
       case "Guitar Tab":
-        return <Guitar className="w-5 h-5 text-orange-600" />
+      case "Guitar Tablature":
+        return <Guitar className={`w-5 h-5 ${styles.icon}`} />
+      case "Chord Chart":
+        return <Music className={`w-5 h-5 ${styles.icon}`} />
       case "Sheet Music":
-        return <Music className="w-5 h-5 text-blue-600" />
+        return <FileText className={`w-5 h-5 ${styles.icon}`} />
+      case "Lyrics":
+        return <FileText className={`w-5 h-5 ${styles.icon}`} />
       default:
         return <FileText className="w-5 h-5 text-gray-600" />
     }

--- a/lib/content-type-styles.ts
+++ b/lib/content-type-styles.ts
@@ -1,0 +1,53 @@
+export interface ContentTypeStyle {
+  ring: string
+  border: string
+  bg: string
+  icon: string
+}
+
+export function getContentTypeStyle(type: string): ContentTypeStyle {
+  switch (type) {
+    case "lyrics":
+    case "Lyrics":
+    case "Lyrics Sheet":
+      return {
+        ring: "ring-green-500",
+        border: "border-green-200",
+        bg: "bg-green-50",
+        icon: "text-green-600",
+      }
+    case "tabs":
+    case "tablature":
+    case "Guitar Tab":
+    case "Guitar Tablature":
+      return {
+        ring: "ring-blue-500",
+        border: "border-blue-200",
+        bg: "bg-blue-50",
+        icon: "text-blue-600",
+      }
+    case "chords":
+    case "Chord Chart":
+      return {
+        ring: "ring-purple-500",
+        border: "border-purple-200",
+        bg: "bg-purple-50",
+        icon: "text-purple-600",
+      }
+    case "sheet":
+    case "Sheet Music":
+      return {
+        ring: "ring-orange-500",
+        border: "border-orange-200",
+        bg: "bg-orange-50",
+        icon: "text-orange-600",
+      }
+    default:
+      return {
+        ring: "ring-gray-500",
+        border: "border-gray-200",
+        bg: "bg-gray-50",
+        icon: "text-gray-600",
+      }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared helper for content type colors
- update Add Content and Create New selectors with color-coded styling
- apply consistent styles for batch import cards and file upload icons
- update metadata form icons to use shared color scheme

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685015a943308329b4fefc5b917168d9