### PR TITLE
Fix DOCX line breaks and PDF detection

### DIFF
--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -148,7 +148,7 @@ export function FileUpload({
     const ext = filename.split(".").pop()?.toLowerCase();
     switch (ext) {
       case "pdf":
-        return "Sheet Music";
+        return "Document";
       case "docx":
         return "Document";
       case "gp5":

--- a/lib/batch-import.ts
+++ b/lib/batch-import.ts
@@ -15,21 +15,28 @@ export async function parseDocxFile(file: File): Promise<ParsedSong[]> {
   let current: ParsedSong | null = null;
 
   for (const p of paragraphs) {
-    const text = p.textContent?.trim() || "";
-    if (!text) continue;
+    let text = p.innerHTML.replace(/<br\s*\/?>/gi, "\n");
+    text = text.replace(/<[^>]+>/g, "");
+    text = text.replace(/\u00A0/g, " ");
+    const trimmed = text.trim();
+
     const boldEl = p.querySelector("strong, b");
     const isBold =
       !!boldEl &&
-      boldEl.textContent?.trim() === text &&
+      boldEl.textContent?.trim() === trimmed &&
       boldEl.parentElement === p;
 
-    if (isBold) {
+    if (isBold && trimmed) {
       if (current) {
         songs.push(current);
       }
-      current = { title: text, body: "" };
+      current = { title: trimmed, body: "" };
     } else if (current) {
-      current.body += text + "\n";
+      if (trimmed === "") {
+        current.body += "\n";
+      } else {
+        current.body += text + "\n";
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- keep blank lines and `<br>` tags when parsing DOCX files
- treat PDF uploads as generic documents instead of sheet music

## Testing
- `npx vitest run`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685050deaf5483298a1c13fc02de0b38