### PR TITLE
Add sheet music upload-only content type

### DIFF
--- a/components/add-content.tsx
+++ b/components/add-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -50,6 +50,13 @@ export function AddContent({
   const [contentType, setContentType] = useState(ContentType.LYRICS);
   const [batchArtist, setBatchArtist] = useState("");
 
+  useEffect(() => {
+    if (contentType === ContentType.SHEET_MUSIC) {
+      setMode("import");
+      setImportMode("single");
+    }
+  }, [contentType]);
+
   const importModes = [
     {
       id: "single",
@@ -63,10 +70,16 @@ export function AddContent({
     },
   ];
 
+  const availableImportModes =
+    contentType === ContentType.SHEET_MUSIC
+      ? importModes.filter((m) => m.id === "single")
+      : importModes;
+
   const contentTypes = [
     { id: "lyrics", name: ContentType.LYRICS, icon: FileText },
     { id: "chords", name: ContentType.CHORD_CHART, icon: Music },
     { id: "tabs", name: ContentType.GUITAR_TAB, icon: Guitar },
+    { id: "sheet", name: ContentType.SHEET_MUSIC, icon: FileText },
   ];
 
   const handleFilesUploaded = (files: any[]) => {
@@ -415,33 +428,35 @@ export function AddContent({
             </CardContent>
           </Card>
 
-          <Card className="border-0 shadow-lg bg-white/80 backdrop-blur-sm">
-            <CardHeader className="py-3 px-4">
-              <CardTitle className="text-lg text-gray-900">Choose How to Add</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 gap-2">
-                <Card
-                  onClick={() => setMode("create")}
-                  className={`cursor-pointer ${mode === "create" ? "ring-2 ring-primary" : "hover:shadow"}`}
-                >
-                  <CardContent className="p-2 text-center space-y-1">
-                    <FileText className="w-6 h-6 mx-auto" />
-                    <p className="text-sm">Create Manually</p>
-                  </CardContent>
-                </Card>
-                <Card
-                  onClick={() => setMode("import")}
-                  className={`cursor-pointer ${mode === "import" ? "ring-2 ring-primary" : "hover:shadow"}`}
-                >
-                  <CardContent className="p-2 text-center space-y-1">
-                    <Upload className="w-6 h-6 mx-auto" />
-                    <p className="text-sm">Import From File</p>
-                  </CardContent>
-                </Card>
-              </div>
-            </CardContent>
-          </Card>
+          {contentType !== ContentType.SHEET_MUSIC && (
+            <Card className="border-0 shadow-lg bg-white/80 backdrop-blur-sm">
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-lg text-gray-900">Choose How to Add</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 gap-2">
+                  <Card
+                    onClick={() => setMode("create")}
+                    className={`cursor-pointer ${mode === "create" ? "ring-2 ring-primary" : "hover:shadow"}`}
+                  >
+                    <CardContent className="p-2 text-center space-y-1">
+                      <FileText className="w-6 h-6 mx-auto" />
+                      <p className="text-sm">Create Manually</p>
+                    </CardContent>
+                  </Card>
+                  <Card
+                    onClick={() => setMode("import")}
+                    className={`cursor-pointer ${mode === "import" ? "ring-2 ring-primary" : "hover:shadow"}`}
+                  >
+                    <CardContent className="p-2 text-center space-y-1">
+                      <Upload className="w-6 h-6 mx-auto" />
+                      <p className="text-sm">Import From File</p>
+                    </CardContent>
+                  </Card>
+                </div>
+              </CardContent>
+            </Card>
+          )}
 
           {mode === "create" ? (
             <ContentCreator
@@ -486,7 +501,7 @@ export function AddContent({
                     <div className="space-y-2">
                       <Label className="text-sm">Import Mode</Label>
                       <div className="grid grid-cols-2 gap-2">
-                        {importModes.map((m) => (
+                        {availableImportModes.map((m) => (
                           <Card
                             key={m.id}
                             onClick={() => setImportMode(m.id as "single" | "batch")}

--- a/components/batch-import.tsx
+++ b/components/batch-import.tsx
@@ -35,8 +35,7 @@ export function BatchImport({ onComplete }: BatchImportProps) {
   const typeMap: Record<ContentTypeId, { type: ContentType; key: string }> = {
     lyrics: { type: ContentType.LYRICS, key: CONTENT_TYPE_KEYS[ContentType.LYRICS] },
     chord_chart: { type: ContentType.CHORD_CHART, key: CONTENT_TYPE_KEYS[ContentType.CHORD_CHART] },
-    tablature: { type: ContentType.GUITAR_TAB, key: CONTENT_TYPE_KEYS[ContentType.GUITAR_TAB] },
-    sheet: { type: ContentType.SHEET_MUSIC, key: CONTENT_TYPE_KEYS[ContentType.SHEET_MUSIC] }
+    tablature: { type: ContentType.GUITAR_TAB, key: CONTENT_TYPE_KEYS[ContentType.GUITAR_TAB] }
   }
 
   const handleFile = async (file: File) => {
@@ -96,8 +95,7 @@ export function BatchImport({ onComplete }: BatchImportProps) {
   const contentTypes = [
     { id: "lyrics" as ContentTypeId, name: ContentType.LYRICS, icon: FileText },
     { id: "chord_chart" as ContentTypeId, name: ContentType.CHORD_CHART, icon: Music },
-    { id: "tablature" as ContentTypeId, name: ContentType.GUITAR_TAB, icon: Guitar },
-    { id: "sheet" as ContentTypeId, name: ContentType.SHEET_MUSIC, icon: FileText }
+    { id: "tablature" as ContentTypeId, name: ContentType.GUITAR_TAB, icon: Guitar }
   ]
 
   if (songs.length === 0) {

--- a/components/content-creator.tsx
+++ b/components/content-creator.tsx
@@ -38,8 +38,7 @@ export function ContentCreator({
   const placeholders: Record<ContentTypeId, string> = {
     lyrics: "Write your lyrics here...",
     chord_chart: "Write your chord chart here...",
-    tablature: "Write your guitar tab here...",
-    sheet: "Write your sheet music here..."
+    tablature: "Write your guitar tab here..."
   }
 
   const tips: Record<ContentTypeId, string[]> = {
@@ -55,26 +54,20 @@ export function ContentCreator({
       "Use numbers for fret positions.",
       "Use dashes (-) or empty beats for rhythm.",
       "Align notes vertically for chords.",
-      "Use | for measure separators.",
-    ],
-    sheet: [
-      "Add musical notation or sheet music content.",
-      "Include tempo, key signature, and other musical markings."
+      "Use | for measure separators."
     ]
   }
 
   const typeNames: Record<ContentTypeId, ContentType> = {
     lyrics: ContentType.LYRICS,
     chord_chart: ContentType.CHORD_CHART,
-    tablature: ContentType.GUITAR_TAB,
-    sheet: ContentType.SHEET_MUSIC
+    tablature: ContentType.GUITAR_TAB
   }
 
   const contentTypes: { id: ContentTypeId; name: ContentType; icon: any; description: string }[] = [
     { id: "lyrics", name: ContentType.LYRICS, icon: FileText, description: "Create lyrics-only sheets" },
     { id: "chord_chart", name: ContentType.CHORD_CHART, icon: Music, description: "Lyrics with chord progressions" },
-    { id: "tablature", name: ContentType.GUITAR_TAB, icon: Guitar, description: "Create simple guitar tabs" },
-    { id: "sheet", name: ContentType.SHEET_MUSIC, icon: FileText, description: "Create sheet music" }
+    { id: "tablature", name: ContentType.GUITAR_TAB, icon: Guitar, description: "Create simple guitar tabs" }
   ]
 
   const handleCreate = () => {

--- a/components/metadata-form.tsx
+++ b/components/metadata-form.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
+import { ContentType } from "@/types/content"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -199,6 +200,9 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
       // Example: if you have files[0].url from uploads:
       if (files && files[0]?.url) {
         payload.file_url = files[0].url
+        if (!payload.content_data && payload.content_type === ContentType.SHEET_MUSIC) {
+          payload.content_data = { file: files[0].url }
+        }
       }
 
       // Insert into Supabase
@@ -249,6 +253,10 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
         file_url: files && files[0]?.url ? files[0].url : null,
         is_favorite: false,
         is_public: false,
+      }
+
+      if (!payload.content_data && payload.content_type === ContentType.SHEET_MUSIC && payload.file_url) {
+        payload.content_data = { file: payload.file_url }
       }
 
       const newContent = await createContent(payload)


### PR DESCRIPTION
## Summary
- support Sheet Music content type
- disable manual creation for Sheet Music
- filter batch import options for Sheet Music
- save Sheet Music file location in content_data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68505f4f2bc083298bdae1aecf5f04fc