### PR TITLE
Fix sheet music embedding and title handling

### DIFF
--- a/components/add-content.tsx
+++ b/components/add-content.tsx
@@ -199,7 +199,7 @@ export function AddContent({
 
         const formattedContent = {
           user_id: user.id,
-          title: contentToSave.title || "Untitled",
+          title: contentToSave.title,
           content_type:
             contentToSave.type === ContentType.SHEET_MUSIC
               ? "sheet_music"

--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -514,17 +514,29 @@ export function ContentViewer({
 
                               {content.file_url ? (
                                 <div className="border rounded-lg overflow-hidden">
-                                  <Image
-                                    src={content.file_url || "/placeholder.svg"}
-                                    alt={`Sheet music for ${content.title}`}
-                                    width={800}
-                                    height={800}
-                                    className="w-full h-auto"
-                                    style={{
-                                      maxHeight: "800px",
-                                      objectFit: "contain",
-                                    }}
-                                  />
+                                  {content.file_url.toLowerCase().endsWith(".pdf") ? (
+                                    <object
+                                      data={content.file_url}
+                                      type="application/pdf"
+                                      className="w-full h-[800px]"
+                                    >
+                                      <p className="p-4">
+                                        Unable to display PDF.{' '}
+                                        <a href={content.file_url} target="_blank" rel="noopener noreferrer">
+                                          Download
+                                        </a>
+                                      </p>
+                                    </object>
+                                  ) : (
+                                    <Image
+                                      src={content.file_url || "/placeholder.svg"}
+                                      alt={`Sheet music for ${content.title}`}
+                                      width={800}
+                                      height={800}
+                                      className="w-full h-auto"
+                                      style={{ maxHeight: "800px", objectFit: "contain" }}
+                                    />
+                                  )}
                                 </div>
                               ) : content.content_data?.notation ? (
                                 <div className="bg-gray-50 p-6 border rounded-lg">

--- a/components/metadata-form.tsx
+++ b/components/metadata-form.tsx
@@ -45,6 +45,7 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [metadata, setMetadata] = useState({
+    title: "",
     artist: "",
     album: "",
     genre: "",
@@ -83,7 +84,7 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
 
   const keys = ["C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B"]
 
-  const basicCompleted = [metadata.artist, metadata.album, metadata.genre].filter(Boolean).length
+  const basicCompleted = [metadata.title, metadata.artist, metadata.album, metadata.genre].filter(Boolean).length
   const musicalCompleted = [metadata.key, metadata.bpm, metadata.timeSignature, metadata.difficulty].filter(Boolean).length
   const organizationCompleted = [
     metadata.tags.length > 0 ? "tags" : "",
@@ -174,10 +175,15 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
         return
       }
 
+      if (!metadata.title.trim()) {
+        alert("Title is required");
+        return;
+      }
+
       // Build the insert payload
       const payload: any = {
         user_id: user.id,
-        title: createdContent?.title || files?.[0]?.name || "Untitled",
+        title: metadata.title.trim(),
         artist: metadata.artist || null,
         album: metadata.album || null,
         genre: metadata.genre || null,
@@ -245,9 +251,15 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
         return
       }
 
+      if (!metadata.title.trim()) {
+        alert("Title is required")
+        setIsSubmitting(false)
+        return
+      }
+
       const payload: any = {
         user_id: user.id,
-        title: createdContent?.title || files?.[0]?.name || "Untitled",
+        title: metadata.title.trim(),
         content_type: createdContent?.type || files?.[0]?.contentType || "unknown",
         content_data: createdContent?.content || {},
         file_url: files && files[0]?.url ? files[0].url : null,
@@ -348,11 +360,20 @@ export function MetadataForm({ files = [], createdContent, onComplete, onBack }:
                 <div className="flex items-center w-full gap-2">
                   <Info className="w-4 h-4 text-blue-600" />
                   <span className="flex-1">Basic Info</span>
-                  {!openSections.includes("basic") && renderSummary(basicCompleted, 3)}
+                  {!openSections.includes("basic") && renderSummary(basicCompleted, 4)}
                 </div>
               </AccordionTrigger>
               <AccordionContent className="px-4 pb-4">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="md:col-span-2">
+                    <Label htmlFor="title">Title *</Label>
+                    <Input
+                      id="title"
+                      value={metadata.title}
+                      onChange={(e) => setMetadata((prev) => ({ ...prev, title: e.target.value }))}
+                      placeholder="Song title"
+                    />
+                  </div>
                   <div>
                     <Label htmlFor="artist">Artist</Label>
                     <Input

--- a/components/performance-mode.tsx
+++ b/components/performance-mode.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { MusicText } from "@/components/music-text"
+import Image from "next/image"
 import {
   X,
   ChevronLeft,
@@ -61,6 +62,9 @@ export function PerformanceMode({
     : defaultSetlist
 
   const lyricsData = songs.map((song: any) => song?.content_data?.lyrics || "")
+  const sheetUrls = songs.map(
+    (song: any) => song?.file_url || song?.content_data?.file || null,
+  )
 
   const toggleFullScreen = () => {
     if (!document.fullscreenElement) {
@@ -311,8 +315,45 @@ export function PerformanceMode({
 
 
             <div className="space-y-8 max-w-3xl mx-auto">
-              {lyricsData[currentSong] ? (
-                <MusicText text={lyricsData[currentSong]} className="text-lg leading-relaxed" />
+              {currentSongData.content_type === "Sheet Music" ? (
+                sheetUrls[currentSong] ? (
+                  sheetUrls[currentSong].toLowerCase().endsWith(".pdf") ? (
+                    <object
+                      data={sheetUrls[currentSong] as string}
+                      type="application/pdf"
+                      className="w-full h-[calc(100vh-200px)]"
+                    >
+                      <p className="p-4">
+                        Unable to display PDF.{' '}
+                        <a
+                          href={sheetUrls[currentSong] as string}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Download
+                        </a>
+                      </p>
+                    </object>
+                  ) : (
+                    <Image
+                      src={sheetUrls[currentSong] as string}
+                      alt={currentSongData.title}
+                      width={800}
+                      height={800}
+                      className="w-full h-auto"
+                      style={{ maxHeight: "100%", objectFit: "contain" }}
+                    />
+                  )
+                ) : (
+                  <div className="text-center text-[#A69B8E] py-10">
+                    <p className="text-xl">No sheet music available</p>
+                  </div>
+                )
+              ) : lyricsData[currentSong] ? (
+                <MusicText
+                  text={lyricsData[currentSong]}
+                  className="text-lg leading-relaxed"
+                />
               ) : (
                 <div className="text-center text-[#A69B8E] py-10">
                   <p className="text-xl">No lyrics available for this song</p>


### PR DESCRIPTION
## Summary
- render PDF files with `<object>` so sheet music displays
- show PDFs in performance mode and support images for sheet music
- require a title when adding metadata and include a title field
- stop using the file name as a fallback title

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6851693e16d4832997ffeddc7b0de5a2