### PR TITLE
Fix edit layout and show PDFs

### DIFF
--- a/app/content/[id]/edit/page.tsx
+++ b/app/content/[id]/edit/page.tsx
@@ -3,13 +3,13 @@
 import { useState, useEffect } from "react"
 import { useRouter, useParams } from "next/navigation"
 import dynamic from "next/dynamic"
-import { toast } from "sonner"
 
-const ContentEditor = dynamic(() => import("@/components/content-editor"), {
-  loading: () => <p>Loading editor...</p>,
-})
+const ContentEditPageClient = dynamic(
+  () => import("@/components/content-edit-page-client"),
+  { loading: () => <p>Loading editor...</p> }
+)
 import { useAuth } from "@/contexts/auth-context"
-import { getContentById, updateContent } from "@/lib/content-service"
+import { getContentById } from "@/lib/content-service"
 import type { Database } from "@/types/supabase"
 
 type Content = Database["public"]["Tables"]["content"]["Row"]
@@ -48,23 +48,6 @@ export default function EditContentPage() {
     }
   }, [params.id, user])
 
-  const handleSave = async (updatedContent: any) => {
-    if (!content) return
-
-    try {
-      await updateContent(content.id, updatedContent)
-      toast.success("Changes saved successfully")
-      // Navigate back to content view
-      router.push(`/content/${content.id}`)
-    } catch (err) {
-      console.error("Error saving content:", err)
-      // Handle error - could show toast notification
-    }
-  }
-
-  const handleCancel = () => {
-    router.push(`/content/${content?.id}`)
-  }
 
   // Don't render anything while auth is loading
   if (isLoading) {
@@ -121,5 +104,5 @@ export default function EditContentPage() {
     )
   }
 
-  return <ContentEditor content={content} onSave={handleSave} onCancel={handleCancel} />
+  return <ContentEditPageClient content={content} />
 }

--- a/components/content-edit-page-client.tsx
+++ b/components/content-edit-page-client.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Database } from "@/types/supabase";
+import dynamic from "next/dynamic";
+import { Sidebar } from "@/components/sidebar";
+import { Header } from "@/components/header";
+import { cn } from "@/lib/utils";
+import { updateContent } from "@/lib/content-service";
+import { toast } from "sonner";
+
+const ContentEditor = dynamic(() => import("@/components/content-editor").then(mod => ({ default: mod.ContentEditor })), {
+  loading: () => <p>Loading editor...</p>,
+});
+
+type Content = Database["public"]["Tables"]["content"]["Row"];
+
+interface ContentEditPageClientProps {
+  content: Content;
+}
+
+export default function ContentEditPageClient({ content }: ContentEditPageClientProps) {
+  const router = useRouter();
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [activeScreen, setActiveScreen] = useState("library");
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
+
+  const handleNavigate = (screen: string) => {
+    router.push(`/${screen}`);
+  };
+
+  const handleSave = async (updatedContent: any) => {
+    try {
+      await updateContent(content.id, updatedContent);
+      toast.success("Changes saved successfully");
+      router.push(`/content/${content.id}`);
+    } catch (err) {
+      console.error("Error saving content:", err);
+    }
+  };
+
+  const handleCancel = () => {
+    router.push(`/content/${content.id}`);
+  };
+
+  return (
+    <div className="flex flex-col h-screen bg-[#fffcf7]">
+      <Header
+        onMenuClick={() => setSidebarMobileOpen(true)}
+        onToggleCollapse={() => setSidebarCollapsed(c => !c)}
+        collapsed={sidebarCollapsed}
+      />
+      <div className="flex flex-1">
+        <Sidebar
+          activeScreen={activeScreen}
+          onNavigate={handleNavigate}
+          collapsed={sidebarCollapsed}
+          onCollapsedChange={setSidebarCollapsed}
+          mobileOpen={sidebarMobileOpen}
+          onMobileOpenChange={setSidebarMobileOpen}
+        />
+        <main
+          className={cn(
+            "flex-1 overflow-auto transition-all duration-300 ease-in-out",
+            sidebarCollapsed ? "md:ml-20" : "md:ml-72"
+          )}
+        >
+          <ContentEditor content={content} onSave={handleSave} onCancel={handleCancel} />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/editors/content-type-editor.tsx
+++ b/components/editors/content-type-editor.tsx
@@ -4,6 +4,7 @@ import { ChordEditor } from "@/components/chord-editor"
 import { LyricsEditor } from "@/components/lyrics-editor"
 import { TabEditor } from "@/components/tab-editor"
 import { AnnotationTools } from "@/components/annotation-tools"
+import PdfViewer from "@/components/pdf-viewer"
 import { ContentType } from "@/types/content"
 
 interface ContentTypeEditorProps {
@@ -44,6 +45,9 @@ export function ContentTypeEditor({ content, onChange }: ContentTypeEditorProps)
         />
       )
     case ContentType.SHEET_MUSIC:
+      if (content.file_url && content.file_url.toLowerCase().endsWith(".pdf")) {
+        return <PdfViewer url={content.file_url} className="h-[800px]" fullscreen />
+      }
       return (
         <AnnotationTools
           content={{

--- a/components/pdf-viewer.tsx
+++ b/components/pdf-viewer.tsx
@@ -3,7 +3,16 @@
 import { useState, useRef, useEffect } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut, Maximize, Minimize } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ZoomIn,
+  ZoomOut,
+  Maximize,
+  Minimize,
+  StretchHorizontal,
+  StretchVertical,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 
 import "react-pdf/dist/esm/Page/TextLayer.css";
@@ -24,6 +33,7 @@ export function PdfViewer({ url, className, fullscreen = false }: PdfViewerProps
   const [scale, setScale] = useState(1);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
 
   const onDocumentLoadSuccess = ({ numPages }: { numPages: number }) => {
     setNumPages(numPages);
@@ -44,12 +54,37 @@ export function PdfViewer({ url, className, fullscreen = false }: PdfViewerProps
     }
   };
 
+  const fitWidth = () => {
+    if (containerSize.width) {
+      setScale(containerSize.width / 800);
+    }
+  };
+
+  const fitPage = () => {
+    if (containerSize.height) {
+      setScale(containerSize.height / 1000);
+    }
+  };
+
   useEffect(() => {
     const handleFsChange = () => {
       setIsFullscreen(!!document.fullscreenElement);
     };
+    const updateSize = () => {
+      if (containerRef.current) {
+        setContainerSize({
+          width: containerRef.current.clientWidth,
+          height: containerRef.current.clientHeight,
+        });
+      }
+    };
+    updateSize();
+    window.addEventListener("resize", updateSize);
     document.addEventListener("fullscreenchange", handleFsChange);
-    return () => document.removeEventListener("fullscreenchange", handleFsChange);
+    return () => {
+      window.removeEventListener("resize", updateSize);
+      document.removeEventListener("fullscreenchange", handleFsChange);
+    };
   }, []);
 
   return (
@@ -78,6 +113,12 @@ export function PdfViewer({ url, className, fullscreen = false }: PdfViewerProps
           <span className="text-sm w-12 text-center">{Math.round(scale * 100)}%</span>
           <Button variant="ghost" size="sm" onClick={() => setScale(Math.min(scale + 0.2, 3))}>
             <ZoomIn className="w-4 h-4" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={fitWidth} title="Fit width">
+            <StretchHorizontal className="w-4 h-4" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={fitPage} title="Fit page">
+            <StretchVertical className="w-4 h-4" />
           </Button>
           {fullscreen && (
             <Button variant="ghost" size="sm" onClick={toggleFullscreen}>


### PR DESCRIPTION
## Summary
- add `ContentEditPageClient` layout component
- display PDF files when editing sheet music
- extend `PdfViewer` with fit controls
- use new layout on `/content/[id]/edit`

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities in app/setup/page.tsx)*
- `pnpm test` *(fails: vitest exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6851748ef0f08329b6e583c37a47acef