### PR TITLE
Fix PDF display for sheet music

### DIFF
--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -309,7 +309,7 @@ export function ContentViewer({
                 <Card className="shadow-xl border border-amber-200 overflow-hidden">
                   <CardContent className="p-0">
                     <div
-                      className="bg-white p-8 min-h-[800px] relative"
+                      className="bg-white p-8 min-h-[calc(100vh-250px)] relative"
                       style={{
                         transform: `scale(${zoom / 100})`,
                         transformOrigin: "top center",
@@ -516,7 +516,11 @@ export function ContentViewer({
                               {content.file_url ? (
                                 <div className="border rounded-lg overflow-hidden">
                                   {content.file_url.toLowerCase().endsWith(".pdf") ? (
-                                    <PdfViewer url={content.file_url} fullscreen className="h-[800px]" />
+                                    <PdfViewer
+                                      url={content.file_url}
+                                      fullscreen
+                                      className="w-full h-[calc(100vh-250px)]"
+                                    />
                                   ) : (
                                     <Image
                                       src={content.file_url || "/placeholder.svg"}
@@ -524,7 +528,10 @@ export function ContentViewer({
                                       width={800}
                                       height={800}
                                       className="w-full h-auto"
-                                      style={{ maxHeight: "800px", objectFit: "contain" }}
+                                      style={{
+                                        maxHeight: "calc(100vh - 250px)",
+                                        objectFit: "contain",
+                                      }}
                                     />
                                   )}
                                 </div>

--- a/components/editors/content-type-editor.tsx
+++ b/components/editors/content-type-editor.tsx
@@ -46,7 +46,13 @@ export function ContentTypeEditor({ content, onChange }: ContentTypeEditorProps)
       )
     case ContentType.SHEET_MUSIC:
       if (content.file_url && content.file_url.toLowerCase().endsWith(".pdf")) {
-        return <PdfViewer url={content.file_url} className="h-[800px]" fullscreen />
+        return (
+          <PdfViewer
+            url={content.file_url}
+            className="w-full h-[calc(100vh-250px)]"
+            fullscreen
+          />
+        )
       }
       return (
         <AnnotationTools

--- a/components/pdf-viewer.tsx
+++ b/components/pdf-viewer.tsx
@@ -18,8 +18,8 @@ import { cn } from "@/lib/utils";
 import "react-pdf/dist/esm/Page/TextLayer.css";
 import "react-pdf/dist/esm/Page/AnnotationLayer.css";
 
-pdfjs.GlobalWorkerOptions.workerSrc =
-  `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
+// Use local worker to avoid cross-origin issues in production
+pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.js";
 
 interface PdfViewerProps {
   url: string;


### PR DESCRIPTION
## Summary
- load pdf.js worker from local file instead of CDN
- make viewer height responsive for sheet music on view/edit pages

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68517902b7688329bf0595d3fe3861d4