### PR TITLE
Fix mobile tab layout

### DIFF
--- a/components/content-editor.tsx
+++ b/components/content-editor.tsx
@@ -310,17 +310,17 @@ export function ContentEditor({ content, onSave, onCancel }: ContentEditorProps)
         <div className="flex-1 overflow-auto">
           <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full">
             <div className="border-b border-gray-200 bg-gray-50 px-4">
-              <TabsList className="flex flex-col sm:flex-row gap-2">
+              <TabsList className="flex flex-col sm:flex-row gap-2 w-full">
                 <TabsTrigger
                   value="content"
-                  className="px-4 py-2 text-sm font-medium border border-gray-200 rounded-t-md bg-gray-100 hover:bg-white data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:border-b-transparent"
+                  className="flex-1 sm:flex-none px-4 py-2 text-sm font-medium border border-gray-300 rounded-xl bg-[#f9fafb] hover:bg-white transition-colors data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:shadow"
                 >
                   <FileText className="w-4 h-4 mr-2" />
                   Content
                 </TabsTrigger>
                 <TabsTrigger
                   value="metadata"
-                  className="px-4 py-2 text-sm font-medium border border-gray-200 rounded-t-md bg-gray-100 hover:bg-white data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:border-b-transparent"
+                  className="flex-1 sm:flex-none px-4 py-2 text-sm font-medium border border-gray-300 rounded-xl bg-[#f9fafb] hover:bg-white transition-colors data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:shadow"
                 >
                   <Music className="w-4 h-4 mr-2" />
                   Details

--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -274,23 +274,23 @@ export function ContentViewer({
         <div className="flex-1 p-6 overflow-auto">
           <Tabs value={activeTab} onValueChange={setActiveTab} className="mb-6">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-              <TabsList className="flex flex-col sm:flex-row gap-2">
+              <TabsList className="flex flex-col sm:flex-row gap-2 w-full">
                 <TabsTrigger
                   value="content"
-                  className="px-4 py-2 text-sm font-medium border border-gray-200 rounded-t-md bg-gray-100 hover:bg-white data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:border-b-transparent"
+                  className="flex-1 sm:flex-none px-4 py-2 text-sm font-medium border border-gray-300 rounded-xl bg-[#f9fafb] hover:bg-white transition-colors data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:shadow"
                 >
                   Content
                 </TabsTrigger>
               <TabsTrigger
                 value="info"
-                className="px-4 py-2 text-sm font-medium border border-gray-200 rounded-t-md bg-gray-100 hover:bg-white data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:border-b-transparent"
+                className="flex-1 sm:flex-none px-4 py-2 text-sm font-medium border border-gray-300 rounded-xl bg-[#f9fafb] hover:bg-white transition-colors data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:shadow"
               >
                 <Info className="w-4 h-4 mr-2" />
                 Details
               </TabsTrigger>
               <TabsTrigger
                 value="notes"
-                className="px-4 py-2 text-sm font-medium border border-gray-200 rounded-t-md bg-gray-100 hover:bg-white data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:border-b-transparent"
+                className="flex-1 sm:flex-none px-4 py-2 text-sm font-medium border border-gray-300 rounded-xl bg-[#f9fafb] hover:bg-white transition-colors data-[state=active]:bg-white data-[state=active]:font-bold data-[state=active]:shadow"
               >
                 <MessageSquare className="w-4 h-4 mr-2" />
                 Notes


### PR DESCRIPTION
## Summary
- fix responsive layout for tab switcher on content editor and viewer

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities)*
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_6851a23d57008329adfcbc3c62f24b99