### PR TITLE
Enhance content tabs with icons and responsive labels

### DIFF
--- a/components/content-editor.tsx
+++ b/components/content-editor.tsx
@@ -27,6 +27,7 @@ import {
   Palette,
   Settings,
   FileText,
+  Info,
   Music,
   Sparkles,
   Clock,
@@ -333,15 +334,15 @@ export function ContentEditor({ content, onSave, onCancel }: ContentEditorProps)
                   value="content"
                   className={`flex-1 sm:flex-none px-4 py-2 text-sm font-medium rounded-lg text-amber-700 hover:bg-amber-50 data-[state=active]:text-white data-[state=active]:bg-gradient-to-r ${headerGradient}`}
                 >
-                  <FileText className="w-4 h-4 mr-2" />
-                  Content
+                  <FileText className="w-4 h-4 sm:mr-2" />
+                  <span className="hidden sm:inline">Content</span>
                 </TabsTrigger>
                 <TabsTrigger
                   value="metadata"
                   className={`flex-1 sm:flex-none px-4 py-2 text-sm font-medium rounded-lg text-amber-700 hover:bg-amber-50 data-[state=active]:text-white data-[state=active]:bg-gradient-to-r ${headerGradient}`}
                 >
-                  <Music className="w-4 h-4 mr-2" />
-                  Details
+                  <Info className="w-4 h-4 sm:mr-2" />
+                  <span className="hidden sm:inline">Details</span>
                 </TabsTrigger>
               </TabsList>
             </div>

--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -329,21 +329,22 @@ export function ContentViewer({
                   value="content"
                   className={`flex-1 sm:flex-none px-4 py-2 text-sm font-medium rounded-lg text-amber-700 hover:bg-amber-50 data-[state=active]:text-white data-[state=active]:bg-gradient-to-r ${getHeaderGradient(content.content_type)}`}
                 >
-                  Content
+                  <FileText className="w-4 h-4 sm:mr-2" />
+                  <span className="hidden sm:inline">Content</span>
                 </TabsTrigger>
                 <TabsTrigger
                   value="info"
                   className={`flex-1 sm:flex-none px-4 py-2 text-sm font-medium rounded-lg text-amber-700 hover:bg-amber-50 data-[state=active]:text-white data-[state=active]:bg-gradient-to-r ${getHeaderGradient(content.content_type)}`}
                 >
-                  <Info className="w-4 h-4 mr-2" />
-                  Details
+                  <Info className="w-4 h-4 sm:mr-2" />
+                  <span className="hidden sm:inline">Details</span>
                 </TabsTrigger>
                 <TabsTrigger
                   value="notes"
                   className={`flex-1 sm:flex-none px-4 py-2 text-sm font-medium rounded-lg text-amber-700 hover:bg-amber-50 data-[state=active]:text-white data-[state=active]:bg-gradient-to-r ${getHeaderGradient(content.content_type)}`}
                 >
-                  <MessageSquare className="w-4 h-4 mr-2" />
-                  Notes
+                  <MessageSquare className="w-4 h-4 sm:mr-2" />
+                  <span className="hidden sm:inline">Notes</span>
                 </TabsTrigger>
               </TabsList>
             </div>


### PR DESCRIPTION
## Summary
- add icons to Content/Details/Notes tabs in viewer
- update editor tabs with icons & Info icon for details
- hide tab labels on small screens
- include Info icon import

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities in setup page)*
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6851d2fdefcc8329a321ff54c6f739d4