### PR TITLE
Fix batch import parsing and preserve formatting

### DIFF
--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -185,7 +185,7 @@ export function FileUpload({
       case "gpx":
         return "Guitar Tab";
       case "txt":
-        return "Chord Chart";
+        return "Document";
       case "mid":
       case "midi":
         return "MIDI File";

--- a/lib/__tests__/batch-import.test.ts
+++ b/lib/__tests__/batch-import.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { parseDocxFile, parsePdfFile } from '../batch-import'
+
+vi.mock('mammoth', () => ({
+  convertToHtml: vi.fn(async () => ({ value: '<p><strong>Song</strong></p><p>Line1<br/>Line2</p><p></p><p>Line3</p>' })),
+  extractRawText: vi.fn(async () => ({ value: 'Song\nLine1\nLine2\n\nLine3\n' }))
+}))
+
+vi.mock('../pdf-utils', () => ({
+  getPdfDocument: vi.fn(async () => ({
+    numPages: 1,
+    getPage: async () => ({
+      getTextContent: async () => ({
+        items: [
+          { str: 'Song A', transform: [1,0,0,1,0,100], fontName: 'Bold' },
+          { str: 'Line 1', transform: [1,0,0,1,0,90], fontName: 'Regular' },
+          { str: 'Line 2', transform: [1,0,0,1,0,80], fontName: 'Regular' },
+          { str: 'Song B', transform: [1,0,0,1,0,70], fontName: 'Bold' },
+          { str: 'Last', transform: [1,0,0,1,0,60], fontName: 'Regular' }
+        ],
+        styles: {
+          Bold: { fontFamily: 'Bold' },
+          Regular: { fontFamily: 'Regular' }
+        }
+      })
+    })
+  }))
+}))
+
+describe('parseDocxFile', () => {
+  it('preserves line breaks from docx', async () => {
+    const file = new File(['dummy'], 'test.docx') as File & { arrayBuffer: () => Promise<ArrayBuffer> }
+    ;(file as any).arrayBuffer = async () => new ArrayBuffer(8)
+    const songs = await parseDocxFile(file)
+    expect(songs).toHaveLength(1)
+    expect(songs[0].title).toBe('Song')
+    expect(songs[0].body).toBe('Line1\nLine2\n\nLine3\n')
+  })
+})
+
+describe('parsePdfFile', () => {
+  it('splits songs when encountering bold lines', async () => {
+    const file = new File(['dummy'], 'test.pdf') as File & { arrayBuffer: () => Promise<ArrayBuffer> }
+    ;(file as any).arrayBuffer = async () => new ArrayBuffer(8)
+    const songs = await parsePdfFile(file)
+    expect(songs).toHaveLength(2)
+    expect(songs[0].title).toBe('Song A')
+    expect(songs[0].body.trim()).toBe('Line 1\nLine 2')
+    expect(songs[1].title).toBe('Song B')
+    expect(songs[1].body.trim()).toBe('Last')
+  })
+})

--- a/lib/batch-import.ts
+++ b/lib/batch-import.ts
@@ -6,75 +6,50 @@ export interface ParsedSong {
 export async function parseDocxFile(file: File): Promise<ParsedSong[]> {
   const mammoth = await import("mammoth");
   const arrayBuffer = await file.arrayBuffer();
-  
-  // Get both HTML (for bold detection) and raw text (for line breaks)
+
+  // Extract HTML for bold detection and raw text for exact line breaks
   const htmlResult = await mammoth.convertToHtml({ arrayBuffer });
   const textResult = await mammoth.extractRawText({ arrayBuffer });
-  
-  // Parse HTML for bold detection
+
+  // Parse HTML to find bold paragraphs which represent song titles
   const parser = new DOMParser();
   const doc = parser.parseFromString(htmlResult.value, "text/html");
   const paragraphs = Array.from(doc.body.querySelectorAll("p"));
-  
-  // Get bold titles from HTML
+
   const boldTitles = new Set<string>();
   for (const p of paragraphs) {
-    let text = p.innerHTML.replace(/<br\s*\/?>/gi, "\n");
-    text = text.replace(/<[^>]+>/g, "");
-    text = text.replace(/\u00A0/g, " ");
-    text = text.replace(/&nbsp;/g, " ");
-    const trimmed = text.trim();
-    
+    const text = (p.textContent || "").replace(/\u00A0/g, " ").trim();
     const boldEl = p.querySelector("strong, b");
-    const isBold = !!boldEl && boldEl.textContent?.trim() === trimmed && boldEl.parentElement === p;
+    const isBold = !!boldEl && boldEl.textContent?.trim() === text && boldEl.parentElement === p;
     const paragraphStyle = p.style.fontWeight || "";
     const isStyledBold = paragraphStyle.includes("bold") || paragraphStyle.includes("700");
-    
-    if ((isBold || isStyledBold) && trimmed.length > 0) {
-      boldTitles.add(trimmed);
+    if ((isBold || isStyledBold) && text.length > 0) {
+      boldTitles.add(text);
     }
   }
-  
-  // Instead of using raw text, let's reconstruct from paragraphs to have better control
-  const textLines: string[] = [];
-  for (const p of paragraphs) {
-    let text = p.innerHTML.replace(/<br\s*\/?>/gi, "\n");
-    text = text.replace(/<[^>]+>/g, "");
-    text = text.replace(/\u00A0/g, " ");
-    text = text.replace(/&nbsp;/g, " ");
-    
-    // Split by internal line breaks and add each as a separate line
-    const internalLines = text.split('\n');
-    for (const internalLine of internalLines) {
-      textLines.push(internalLine);
-    }
-  }
-  
-  // Now process like text parser
+
+  // Use the raw text from Mammoth for accurate line breaks
+  const textLines = textResult.value.split(/\r?\n/);
+
   const songs: ParsedSong[] = [];
   let current: ParsedSong | null = null;
 
-  for (let i = 0; i < textLines.length; i++) {
-    const raw = textLines[i];
+  for (const raw of textLines) {
     const line = raw.trim();
-    
-    // Skip empty lines when looking for titles, but preserve them in song bodies
+
     if (!line) {
-      if (current) {
-        current.body += "\n";
-      }
+      if (current) current.body += "\n";
       continue;
     }
-    
-    // Check if this line is a known title from bold detection
-    const isTitle = boldTitles.has(line);
-    
-    if (isTitle) {
-      if (current) songs.push(current);
+
+    if (boldTitles.has(line)) {
+      if (current) {
+        current.body = current.body.replace(/\n+$/, "\n");
+        songs.push(current);
+      }
       current = { title: line, body: "" };
     } else {
       if (!current) {
-        // First line of the document becomes the title if no current song
         current = { title: line, body: "" };
       } else {
         current.body += raw + "\n";
@@ -82,7 +57,10 @@ export async function parseDocxFile(file: File): Promise<ParsedSong[]> {
     }
   }
 
-  if (current) songs.push(current);
+  if (current) {
+    current.body = current.body.replace(/\n+$/, "\n");
+    songs.push(current);
+  }
   return songs;
 }
 
@@ -91,7 +69,7 @@ export async function parsePdfFile(file: File): Promise<ParsedSong[]> {
   
   const arrayBuffer = await file.arrayBuffer();
   const pdf = await getPdfDocument(arrayBuffer);
-  const lines: { text: string; bold: boolean; fontSize: number; isEmpty: boolean }[] = [];
+  const lines: { text: string; bold: boolean; isEmpty: boolean }[] = [];
 
   for (let i = 1; i <= pdf.numPages; i++) {
     const page = await pdf.getPage(i);
@@ -99,102 +77,52 @@ export async function parsePdfFile(file: File): Promise<ParsedSong[]> {
     let line = "";
     let lastY: number | null = null;
     let bold = false;
-    let fontSize = 12;
     
     for (const item of content.items as any[]) {
       const tx = item.transform[5];
-      const currentFontSize = item.transform[0] || 12;
       
       // Check if this is a new line (different Y coordinate)
       if (lastY !== null && Math.abs(tx - lastY) > 2) {
         // Always add the line, even if empty, to preserve spacing
-        lines.push({ text: line.trim(), bold, fontSize, isEmpty: !line.trim() });
+        lines.push({ text: line.trim(), bold, isEmpty: !line.trim() });
         line = item.str;
-        // Detect bold text from font name or style
-        bold = /Bold|bold|Heavy|Black/i.test(item.fontName || "") || 
-              /Bold|bold|Heavy|Black/i.test(content.styles?.[item.fontName]?.fontFamily || "");
-        fontSize = currentFontSize;
+        bold = /Bold|bold|Heavy|Black/i.test(item.fontName || "") ||
+               /Bold|bold|Heavy|Black/i.test(content.styles?.[item.fontName]?.fontFamily || "");
       } else {
         line += item.str;
-        // Update bold status - if any part of the line is bold, consider it bold
-        bold = bold || /Bold|bold|Heavy|Black/i.test(item.fontName || "") || 
-              /Bold|bold|Heavy|Black/i.test(content.styles?.[item.fontName]?.fontFamily || "");
-        fontSize = Math.max(fontSize, currentFontSize);
+        bold = bold || /Bold|bold|Heavy|Black/i.test(item.fontName || "") ||
+               /Bold|bold|Heavy|Black/i.test(content.styles?.[item.fontName]?.fontFamily || "");
       }
       lastY = tx;
     }
     // Always add the final line
-    lines.push({ text: line.trim(), bold, fontSize, isEmpty: !line.trim() });
+    lines.push({ text: line.trim(), bold, isEmpty: !line.trim() });
   }
 
   const songs: ParsedSong[] = [];
   let current: ParsedSong | null = null;
-  
-  // Calculate average font size to detect larger titles (only from non-empty lines)
-  const nonEmptyLines = lines.filter(line => !line.isEmpty);
-  const avgFontSize = nonEmptyLines.length > 0 
-    ? nonEmptyLines.reduce((sum, line) => sum + line.fontSize, 0) / nonEmptyLines.length 
-    : 12;
-  
+
   for (const ln of lines) {
     const text = ln.text.trim();
-    
-    // Handle empty lines - preserve them in song bodies
+
     if (ln.isEmpty) {
-      if (current) {
-        current.body += "\n";
-      }
+      if (current) current.body += "\n";
       continue;
     }
-    
-    // Multiple strategies to detect song titles:
-    // 1. Bold text
-    // 2. Larger font size (significantly larger than average)
-    // 3. All uppercase text (but not too long to avoid false positives)
-    // 4. Text that looks like a title pattern
-    const isLargerFont = ln.fontSize > avgFontSize * 1.2;
-    const isAllCaps = text === text.toUpperCase() && text.length <= 60 && text.length > 2;
-    const looksLikeTitle = /^[A-Z][A-Za-z\s\-']{2,50}$/.test(text) && !text.includes('.');
-    const isShortLine = text.length <= 60;
-    
-    const isTitle = (ln.bold || isLargerFont || (isAllCaps && isShortLine)) && 
-                   text.length > 1 && 
-                   !text.match(/^(page|p\.|chapter|ch\.|verse|chorus|bridge|\d+)$/i);
-    
-    if (isTitle) {
-      if (current) {
-        songs.push(current);
+
+    if (ln.bold) {
+      if (current) songs.push(current);
+      current = { title: text, body: "" };
+    } else {
+      if (!current) {
+        current = { title: text, body: "" };
+      } else {
+        current.body += text + "\n";
       }
-      current = { title: text, body: "" };
-    } else if (current) {
-      current.body += text + "\n";
-    } else if (!isTitle && looksLikeTitle) {
-      // If we don't have a current song and this looks like a title, start a new one
-      current = { title: text, body: "" };
     }
   }
-  
+
   if (current) songs.push(current);
-  
-  // If no songs were detected using the above logic, try a simpler approach
-  if (songs.length === 0 && nonEmptyLines.length > 0) {
-    // Fallback: treat the first non-empty line as title and rest as body
-    current = { title: nonEmptyLines[0].text || "Untitled", body: "" };
-    let foundTitle = false;
-    for (const line of lines) {
-      if (line.isEmpty) {
-        if (foundTitle) current.body += "\n";
-      } else if (!foundTitle && line.text === current.title) {
-        foundTitle = true;
-      } else if (foundTitle) {
-        current.body += line.text + "\n";
-      }
-    }
-    if (current.body.trim()) {
-      songs.push(current);
-    }
-  }
-  
   return songs;
 }
 


### PR DESCRIPTION
## Summary
- preserve line breaks and bold titles when parsing DOCX
- simplify PDF parsing to split on bold lines
- avoid forcing TXT files to chord chart
- add unit tests for DOCX and PDF parsing

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6851d7c364d483299678b0281a323ab4