### PR TITLE
Fix docx batch import line breaks

### DIFF
--- a/lib/batch-import.ts
+++ b/lib/batch-import.ts
@@ -28,8 +28,19 @@ export async function parseDocxFile(file: File): Promise<ParsedSong[]> {
     }
   }
 
-  // Use the raw text from Mammoth for accurate line breaks
-  const textLines = textResult.value.split(/\r?\n/);
+  // Use the raw text from Mammoth for accurate line breaks. When Mammoth outputs
+  // four consecutive newlines it represents an empty paragraph. In that case we
+  // collapse the normal double newlines inserted after each paragraph so that
+  // line breaks are not duplicated while still preserving intentional blank
+  // lines.
+  let normalized = textResult.value.replace(/\r/g, "");
+  if (normalized.includes("\n\n\n\n")) {
+    normalized = normalized
+      .replace(/\n{4}/g, "<BLANK>")
+      .replace(/\n{2}/g, "\n")
+      .replace(/<BLANK>/g, "\n\n");
+  }
+  const textLines = normalized.split("\n");
 
   const songs: ParsedSong[] = [];
   let current: ParsedSong | null = null;


### PR DESCRIPTION
## Summary
- handle Mammoth output to avoid doubling line breaks

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6851eb2b43408329aeafa59e04968300