### PR TITLE
Implement library pagination

### DIFF
--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { getSupabaseServerClient } from "@/lib/supabase-server";
-import { getUserContentServer } from "@/lib/content-service-server";
+import { getUserContentPageServer } from "@/lib/content-service-server";
 import LibraryPageClient from "@/components/library-page-client";
 
 export default async function LibraryPage({
@@ -17,9 +17,23 @@ export default async function LibraryPage({
     redirect("/login");
   }
 
-  const content = await getUserContentServer();
   const resolved = await searchParams;
   const search = resolved?.search || "";
+  const page = resolved?.page ? parseInt(resolved.page, 10) : 1;
+  const pageSize = 20;
+  const { data, total } = await getUserContentPageServer({
+    page,
+    pageSize,
+    search,
+  });
 
-  return <LibraryPageClient initialContent={content} initialSearch={search} />;
+  return (
+    <LibraryPageClient
+      initialContent={data}
+      initialTotal={total}
+      initialPage={page}
+      pageSize={pageSize}
+      initialSearch={search}
+    />
+  );
 }

--- a/components/library-page-client.tsx
+++ b/components/library-page-client.tsx
@@ -8,11 +8,17 @@ import { cn } from "@/lib/utils";
 
 interface LibraryPageClientProps {
   initialContent: any[]
+  initialTotal: number
+  initialPage: number
+  pageSize: number
   initialSearch?: string
 }
 
 export default function LibraryPageClient({
   initialContent,
+  initialTotal,
+  initialPage,
+  pageSize,
   initialSearch,
 }: LibraryPageClientProps) {
   const router = useRouter();
@@ -54,6 +60,9 @@ export default function LibraryPageClient({
           <Library
             onSelectContent={handleSelectContent}
             initialContent={initialContent}
+            initialTotal={initialTotal}
+            initialPage={initialPage}
+            initialPageSize={pageSize}
             initialSearch={initialSearch}
           />
         </main>


### PR DESCRIPTION
## Summary
- paginate library results server-side and preserve search parameters
- display and fetch paged results in the library client
- add dropdown for page size and next/prev controls
- expose pagination helpers in content services

## Testing
- `npx --no-install vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6851fdcc06d48329a78abb1fe36b9132