### PR TITLE
Fix unescaped characters for lint

### DIFF
--- a/app/_offline/page.tsx
+++ b/app/_offline/page.tsx
@@ -53,7 +53,7 @@ export default function OfflinePage() {
             <div className="mx-auto w-16 h-16 bg-amber-100 rounded-full flex items-center justify-center mb-4">
               <WifiOff className="w-8 h-8 text-amber-600" />
             </div>
-            <CardTitle className="text-amber-900">You're Offline</CardTitle>
+            <CardTitle className="text-amber-900">You&apos;re Offline</CardTitle>
           </CardHeader>
           <CardContent className="text-center space-y-4">
             <p className="text-amber-700">

--- a/components/pwa-install-prompt.tsx
+++ b/components/pwa-install-prompt.tsx
@@ -204,8 +204,8 @@ export function EnhancedPwaInstallPrompt() {
               <h4 className="font-medium text-blue-900 mb-2">iOS Installation:</h4>
               <ol className="text-sm text-blue-800 space-y-1">
                 <li>1. Tap the Share button in Safari</li>
-                <li>2. Scroll down and tap "Add to Home Screen"</li>
-                <li>3. Tap "Add" to install Octavia</li>
+                <li>2. Scroll down and tap &quot;Add to Home Screen&quot;</li>
+                <li>3. Tap &quot;Add&quot; to install Octavia</li>
               </ol>
             </div>
           )}


### PR DESCRIPTION
## Summary
- escape the offline title apostrophe
- escape quotes in PWA install instructions
- run `npm run lint`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68530aab81588329ba6601fa596acd37