### PR TITLE
Fix SetlistManager removal recursion

### DIFF
--- a/components/setlist-manager.tsx
+++ b/components/setlist-manager.tsx
@@ -31,7 +31,7 @@ import {
   createSetlist,
   deleteSetlist,
   addSongToSetlist,
-  removeSongFromSetlist,
+  removeSongFromSetlist as removeSongFromSetlistService,
 } from "@/lib/setlist-service"
 import { getUserContent as getContentList } from "@/lib/content-service"
 import type { Database } from "@/types/supabase"
@@ -230,8 +230,8 @@ function useSetlistOperations() {
     setOperationInProgress(prev => ({ ...prev, [`remove-${setlistSongId}`]: true }))
     try {
       logger.log("Removing song from setlist:", setlistSongId)
-      
-      await removeSongFromSetlist(setlistSongId)
+
+      await removeSongFromSetlistService(setlistSongId)
       await loadData() // Reload to get updated positions
       
       logger.log("Song removed successfully")


### PR DESCRIPTION
## Summary
- fix naming clash in `SetlistManager`

## Testing
- `pnpm exec vitest run`
- `pnpm exec next lint`


------
https://chatgpt.com/codex/tasks/task_e_68533103e8a883299a32ad678afeea1c