### PR TITLE
Improve offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ We welcome contributions! Here's how you can help:
 
 Automated unit tests live in `lib/__tests__` and are executed with [Vitest](https://vitest.dev). Run `npm test` to execute them.
 
+### Offline Support
+
+The application includes a basic offline mode backed by IndexedDB. A health check endpoint (`/api/health`) lets the client detect when connectivity returns. Library data viewed while online is cached locally so it can be accessed from the dedicated offline page when the network is unavailable.
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/app/_offline/page.tsx
+++ b/app/_offline/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { getCachedContent } from "@/lib/offline-cache"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Wifi, WifiOff, RefreshCw, Music, Download } from "lucide-react"
@@ -10,32 +11,27 @@ export default function OfflinePage() {
   const [cachedContent, setCachedContent] = useState<any[]>([])
 
   useEffect(() => {
-    // Check for cached content in localStorage or IndexedDB
     const loadCachedContent = async () => {
-      try {
-        // This would load from your offline storage
-        const cached = localStorage.getItem('octavia-offline-content')
-        if (cached) {
-          setCachedContent(JSON.parse(cached))
-        }
-      } catch (error) {
-        console.error('Failed to load cached content:', error)
-      }
+      const cached = await getCachedContent()
+      setCachedContent(cached)
     }
-    
+
     loadCachedContent()
   }, [])
 
   const handleRetry = async () => {
     setIsRetrying(true)
     try {
-      // Check if we're back online
-      const response = await fetch('/api/health', { 
-        method: 'HEAD',
-        cache: 'no-cache' 
-      })
-      if (response.ok) {
-        window.location.reload()
+      if (navigator.onLine) {
+        const response = await fetch('/api/health', {
+          method: 'HEAD',
+          cache: 'no-cache'
+        })
+        if (response.ok) {
+          window.location.reload()
+        }
+      } else {
+        throw new Error('offline')
       }
     } catch (error) {
       // Still offline

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' })
+}
+
+export function HEAD() {
+  return new Response(null, { status: 200 })
+}

--- a/components/library.tsx
+++ b/components/library.tsx
@@ -116,19 +116,8 @@ export function Library({
           setContent(result.data)
           setTotalCount(result.total)
           try {
-            const existing = JSON.parse(
-              localStorage.getItem('octavia-offline-content') || '[]'
-            ) as any[]
-            const merged = [
-              ...existing.filter(
-                (item) => !result.data.some((c: any) => c.id === item.id)
-              ),
-              ...result.data,
-            ]
-            localStorage.setItem(
-              'octavia-offline-content',
-              JSON.stringify(merged)
-            )
+            const { saveContent } = await import('../lib/offline-cache')
+            await saveContent(result.data)
           } catch (err) {
             console.error('Failed to cache offline content', err)
           }
@@ -228,14 +217,8 @@ export function Library({
       setContent(data);
       setTotalCount(total);
       try {
-        const existing = JSON.parse(
-          localStorage.getItem('octavia-offline-content') || '[]'
-        ) as any[]
-        const merged = [
-          ...existing.filter((item) => !data.some((c: any) => c.id === item.id)),
-          ...data,
-        ]
-        localStorage.setItem('octavia-offline-content', JSON.stringify(merged))
+        const { saveContent } = await import('../lib/offline-cache')
+        await saveContent(data)
       } catch (err) {
         console.error('Failed to cache offline content', err)
       }

--- a/lib/__tests__/health-endpoint.test.ts
+++ b/lib/__tests__/health-endpoint.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+
+it('GET returns 200', async () => {
+  const mod = await import('../../app/api/health/route')
+  const res = mod.GET()
+  expect(res.status).toBe(200)
+})
+
+it('HEAD returns 200', async () => {
+  const mod = await import('../../app/api/health/route')
+  const res = mod.HEAD()
+  expect(res.status).toBe(200)
+})

--- a/lib/__tests__/offline-cache.test.ts
+++ b/lib/__tests__/offline-cache.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import * as cache from '../offline-cache'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('offline cache', () => {
+  it('returns empty array when no cache', async () => {
+    const data = await cache.getCachedContent()
+    expect(Array.isArray(data)).toBe(true)
+    expect(data.length).toBe(0)
+  })
+
+  it('saves and merges content', async () => {
+    await cache.saveContent([{ id: 1, title: 'A' }])
+    await cache.saveContent([{ id: 2, title: 'B' }])
+    const data = await cache.getCachedContent()
+    expect(data).toHaveLength(2)
+  })
+})

--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -1,0 +1,26 @@
+import localforage from 'localforage'
+
+const STORE_KEY = 'octavia-offline-content'
+
+export async function getCachedContent(): Promise<any[]> {
+  try {
+    const data = await localforage.getItem<any[]>(STORE_KEY)
+    return data || []
+  } catch (err) {
+    console.error('Failed to load cached content:', err)
+    return []
+  }
+}
+
+export async function saveContent(items: any[]): Promise<void> {
+  try {
+    const existing = (await localforage.getItem<any[]>(STORE_KEY)) || []
+    const merged = [
+      ...existing.filter((ex: any) => !items.some((it: any) => it.id === ex.id)),
+      ...items,
+    ]
+    await localforage.setItem(STORE_KEY, merged)
+  } catch (err) {
+    console.error('Failed to cache offline content', err)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "embla-carousel-react": "8.5.1",
     "happy-dom": "latest",
     "input-otp": "1.4.1",
+    "localforage": "1.10.0",
     "lucide-react": "^0.454.0",
     "mammoth": "^1.9.1",
     "next": "15.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      localforage:
+        specifier: 1.10.0
+        version: 1.10.0
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.0.0)
@@ -3939,6 +3942,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
@@ -3956,6 +3962,9 @@ packages:
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -9515,6 +9524,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -9530,6 +9543,10 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
 
   locate-path@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add /api/health endpoint
- switch offline caching to IndexedDB via localforage
- load cached content on offline page using new helper
- add offline documentation
- test health endpoint and caching logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e1457ecc8329bae2c008b59e66ea