### PR TITLE
Fix stale callbacks in SetlistManager

### DIFF
--- a/components/setlist-manager.tsx
+++ b/components/setlist-manager.tsx
@@ -203,7 +203,7 @@ function useSetlistOperations() {
     } finally {
       setOperationInProgress(prev => ({ ...prev, create: false }))
     }
-  }, [user])
+  }, [user, setlists])
 
   const deleteExistingSetlist = useCallback(async (setlistId: string) => {
     setOperationInProgress(prev => ({ ...prev, [setlistId]: true }))
@@ -227,7 +227,7 @@ function useSetlistOperations() {
     } finally {
       setOperationInProgress(prev => ({ ...prev, [setlistId]: false }))
     }
-  }, [])
+  }, [setlists])
 
   const addSongsToSetlist = useCallback(async (setlistId: string, songIds: string[]) => {
     const operationKey = `add-${setlistId}`


### PR DESCRIPTION
## Summary
- add `setlists` dependency in SetlistManager callbacks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853f44d77d48329ac0799103be3fa89