### PR TITLE
Disable eager offline caching

### DIFF
--- a/components/library.tsx
+++ b/components/library.tsx
@@ -117,9 +117,8 @@ export function Library({
           setContent(result.data)
           setTotalCount(result.total)
           try {
-            const { saveContent, cacheFilesForContent } = await import('../lib/offline-cache')
+            const { saveContent } = await import('../lib/offline-cache')
             await saveContent(result.data)
-            await cacheFilesForContent(result.data)
           } catch (err) {
             console.error('Failed to cache offline content', err)
           }
@@ -216,6 +215,17 @@ export function Library({
     setDeleteDialog(true);
   };
 
+  const handleDownloadContent = async (content: any) => {
+    try {
+      const { cacheFileForContent } = await import('../lib/offline-cache')
+      await cacheFileForContent(content)
+      toast.success('Content cached for offline use')
+    } catch (err) {
+      console.error('Failed to cache content', err)
+      toast.error('Download failed')
+    }
+  };
+
   const confirmDelete = async () => {
     if (!contentToDelete) return;
 
@@ -231,9 +241,8 @@ export function Library({
       setContent(data);
       setTotalCount(total);
       try {
-        const { saveContent, cacheFilesForContent } = await import('../lib/offline-cache')
+        const { saveContent } = await import('../lib/offline-cache')
         await saveContent(data)
-        await cacheFilesForContent(data)
       } catch (err) {
         console.error('Failed to cache offline content', err)
       }
@@ -520,7 +529,7 @@ export function Library({
                         <Share className="w-4 h-4 mr-2" />
                         Share
                       </DropdownMenuItem>
-                      <DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => handleDownloadContent(item)}>
                         <Download className="w-4 h-4 mr-2" />
                         Download
                       </DropdownMenuItem>
@@ -669,7 +678,7 @@ export function Library({
                           <Share className="w-4 h-4 mr-2" />
                           Share
                         </DropdownMenuItem>
-                        <DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleDownloadContent(item)}>
                           <Download className="w-4 h-4 mr-2" />
                           Download
                         </DropdownMenuItem>

--- a/components/setlist-manager.tsx
+++ b/components/setlist-manager.tsx
@@ -148,13 +148,6 @@ function useSetlistOperations() {
       } catch (err) {
         console.error('Failed to cache offline setlists', err)
       }
-      try {
-        const { cacheFilesForContent } = await import('../lib/offline-cache')
-        const songs = setlistsData.flatMap(s => s.setlist_songs?.map((ss: any) => ss.content) || [])
-        await cacheFilesForContent([...contentData, ...songs])
-      } catch (err) {
-        console.error('Failed to cache files for offline', err)
-      }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load data'
       logger.error("Error loading setlist data:", err)

--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -80,6 +80,11 @@ export async function cacheFilesForContent(items: any[]): Promise<void> {
   }
 }
 
+export async function cacheFileForContent(item: any): Promise<void> {
+  if (!item) return
+  await cacheFilesForContent([item])
+}
+
 export async function getCachedFileUrl(id: string): Promise<string | null> {
   try {
     const stored = await localforage.getItem<any>(`${FILE_PREFIX}${id}`)


### PR DESCRIPTION
## Summary
- add `cacheFileForContent` util for caching single item
- stop prefetching all content files on library pages
- provide `Download` option to cache files on demand
- remove eager caching of setlist files

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68541e7382a08329a523705936f59929