### PR TITLE
Fix offline caching cross-domain issue

### DIFF
--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.searchParams.get('url')
+  if (!url) {
+    return new Response('Missing url', { status: 400 })
+  }
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      return new Response('Fetch failed', { status: res.status })
+    }
+    const headers = new Headers(res.headers)
+    return new Response(res.body, { status: res.status, headers })
+  } catch (err) {
+    console.error('Proxy error', err)
+    return new Response('Error fetching resource', { status: 500 })
+  }
+}

--- a/lib/__tests__/offline-cache.test.ts
+++ b/lib/__tests__/offline-cache.test.ts
@@ -25,12 +25,13 @@ describe('offline cache', () => {
 
   it('caches file blobs and returns url', async () => {
     const buffer = new TextEncoder().encode('hello')
-    global.fetch = vi.fn(async () => ({
+    global.fetch = vi.fn(async (input: RequestInfo) => ({
       ok: true,
       arrayBuffer: async () => buffer,
       headers: { get: () => 'text/plain' }
     })) as any
     await cache.cacheFilesForContent([{ id: '1', file_url: 'https://x.test/a.txt' }])
+    expect((global.fetch as any).mock.calls[0][0]).toBe('/api/proxy?url=' + encodeURIComponent('https://x.test/a.txt'))
     const url = await cache.getCachedFileUrl('1')
     expect(typeof url).toBe('string')
     expect(url!.startsWith('blob:') || url!.startsWith('data:')).toBe(true)

--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -62,7 +62,8 @@ export async function cacheFilesForContent(items: any[]): Promise<void> {
     try {
       const existing = await localforage.getItem<any>(key)
       if (!existing) {
-        const res = await fetch(item.file_url)
+        const proxyUrl = `/api/proxy?url=${encodeURIComponent(item.file_url)}`
+        const res = await fetch(proxyUrl)
         if (!res.ok) throw new Error('fetch failed')
         const array = await res.arrayBuffer()
         const mime = res.headers.get('Content-Type') || 'application/octet-stream'


### PR DESCRIPTION
## Summary
- proxy external file fetches through new `/api/proxy` route to avoid CORS failures
- use the proxy in offline caching logic
- verify proxy usage in tests

## Testing
- `pnpm exec vitest run`
- `pnpm exec next lint`


------
https://chatgpt.com/codex/tasks/task_e_685428cdf1c88329abbe9c9bf0bc6f2b