### PR TITLE
Improve offline file caching docs and errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET=content-files
-ALLOWED_PROXY_HOSTS=
+# Allowed comma-separated hostnames for the /api/proxy endpoint
+ALLOWED_PROXY_HOSTS=demo.supabase.co,imslp.org,uploads.musescore.com

--- a/README.md
+++ b/README.md
@@ -126,9 +126,17 @@ pnpm install
 # Copy environment variables and fill in your Supabase credentials
 cp .env.example .env
 
+# Update `ALLOWED_PROXY_HOSTS` if you plan to import files from
+# external URLs. This variable accepts a comma-separated list of
+# hostnames that the `/api/proxy` endpoint will allow.
+
 # Run development server
 pnpm run dev
 \`\`\`
+
+The `ALLOWED_PROXY_HOSTS` variable controls which domains the
+offline cache proxy will fetch from. Add any additional hosts
+you need for external imports (comma‑separated).
 
 ### First Steps
 1. **Import Content**: Start by uploading your existing sheet music and tabs

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -21,7 +21,7 @@ export async function GET(req: NextRequest) {
   }
 
   if (!allowedHosts.includes(target.host)) {
-    return new Response('URL not allowed', { status: 400 })
+    return new Response('URL not allowed. Configure ALLOWED_PROXY_HOSTS.', { status: 400 })
   }
 
   const supabase = await getSupabaseServerClient()

--- a/components/library.tsx
+++ b/components/library.tsx
@@ -222,7 +222,8 @@ export function Library({
       toast.success('Content cached for offline use')
     } catch (err) {
       console.error('Failed to cache content', err)
-      toast.error('Download failed')
+      const message = err instanceof Error ? err.message : 'Download failed'
+      toast.error(message)
     }
   };
 

--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -64,7 +64,10 @@ export async function cacheFilesForContent(items: any[]): Promise<void> {
       if (!existing) {
         const proxyUrl = `/api/proxy?url=${encodeURIComponent(item.file_url)}`
         const res = await fetch(proxyUrl)
-        if (!res.ok) throw new Error('fetch failed')
+        if (!res.ok) {
+          const text = await res.text().catch(() => '')
+          throw new Error(text || 'fetch failed')
+        }
         const array = await res.arrayBuffer()
         const mime = res.headers.get('Content-Type') || 'application/octet-stream'
         await localforage.setItem(key, { mime, data: array })


### PR DESCRIPTION
## Summary
- document `ALLOWED_PROXY_HOSTS` in setup steps
- show multiple domains in `.env.example`
- return clearer message when proxy rejects a URL
- surface proxy error text in library UI
- propagate proxy error messages from offline cache

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68543333e2588329b83ab82f733707fe