### PR TITLE
Fix insecure cookie usage

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -47,28 +47,9 @@ export async function middleware(request: NextRequest) {
     },
   )
 
-  const userCookie = request.cookies.get("sb-user")?.value
-  let user
-
-  if (userCookie) {
-    try {
-      user = JSON.parse(userCookie)
-    } catch {
-      user = null
-    }
-  }
-
-  if (!user) {
-    const {
-      data: { user: fetchedUser },
-    } = await supabase.auth.getUser()
-    user = fetchedUser
-    if (user) {
-      response.cookies.set("sb-user", JSON.stringify(user), { path: "/" })
-    } else {
-      response.cookies.set("sb-user", "", { path: "/", maxAge: 0 })
-    }
-  }
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
 
   const protectedRoutes = ["/dashboard", "/library", "/setlists", "/settings", "/profile", "/add-content", "/content"]
   const isProtectedRoute = protectedRoutes.some((route) => request.nextUrl.pathname.startsWith(route))


### PR DESCRIPTION
## Summary
- remove `sb-user` cookie and always get the user from Supabase

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685449a50fec832986d4364c9cef703b