### PR TITLE
Fix proxy route env guard

### DIFF
--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -1,7 +1,16 @@
 import { NextRequest } from 'next/server'
 import { getSupabaseServerClient } from '@/lib/supabase-server'
 
-const allowedHosts = (process.env.ALLOWED_PROXY_HOSTS ?? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL || '').host).split(',').map(h => h.trim()).filter(Boolean)
+const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+if (!baseUrl) {
+  console.error('NEXT_PUBLIC_SUPABASE_URL not set')
+  throw new Error('Server misconfiguration')
+}
+const defaultHost = new URL(baseUrl).host
+const allowedHosts = (process.env.ALLOWED_PROXY_HOSTS ?? defaultHost)
+  .split(',')
+  .map(h => h.trim())
+  .filter(Boolean)
 
 const RATE_LIMIT_WINDOW_MS = 60_000
 const RATE_LIMIT_MAX = 20


### PR DESCRIPTION
## Summary
- guard `NEXT_PUBLIC_SUPABASE_URL` when computing proxy allowed hosts

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68546bbdcb948329876c05e0399add26