### PR TITLE
Debounce library search input

### DIFF
--- a/components/library.tsx
+++ b/components/library.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useDebounce } from "@/hooks/use-debounce";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -79,6 +80,7 @@ export function Library({
 }: LibraryProps) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState(initialSearch || "");
+  const debouncedSearch = useDebounce(searchQuery, 300);
   const [sortBy, setSortBy] = useState<"recent" | "title" | "artist">("recent");
   const [viewMode, setViewMode] = useState("grid");
   const [content, setContent] = useState<any[]>(initialContent);
@@ -105,7 +107,7 @@ export function Library({
         const result = await getUserContentPage({
           page,
           pageSize,
-          search: searchQuery,
+          search: debouncedSearch,
           sortBy,
           filters: selectedFilters,
         })
@@ -158,7 +160,7 @@ export function Library({
     return () => {
       cancelled = true
     }
-  }, [searchQuery, sortBy, selectedFilters, page, pageSize])
+  }, [debouncedSearch, sortBy, selectedFilters, page, pageSize])
 
   const getContentIcon = (type: string) => {
     switch (type) {

--- a/hooks/__tests__/use-debounce.test.tsx
+++ b/hooks/__tests__/use-debounce.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { useDebounce } from '../use-debounce'
+
+describe('useDebounce', () => {
+  it('updates value after delay', () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'a', delay: 200 } }
+    )
+
+    expect(result.current).toBe('a')
+    rerender({ value: 'ab', delay: 200 })
+    act(() => {
+      vi.advanceTimersByTime(199)
+    })
+    expect(result.current).toBe('a')
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe('ab')
+    vi.useRealTimers()
+  })
+})

--- a/hooks/use-debounce.ts
+++ b/hooks/use-debounce.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay)
+    return () => {
+      clearTimeout(handle)
+    }
+  }, [value, delay])
+
+  return debounced
+}


### PR DESCRIPTION
## Summary
- debounce search field using new `useDebounce` hook
- call fetch with the debounced value
- add unit tests for `useDebounce`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68547b6df9388329bc53ef039f1da968