### PR TITLE
Fix offline cache imports

### DIFF
--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
+import { getCachedFileUrl } from "@/lib/offline-cache";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -82,7 +83,6 @@ export function ContentViewer({
   useEffect(() => {
     let url: string | null = null;
     const load = async () => {
-      const { getCachedFileUrl } = await import('../lib/offline-cache');
       url = await getCachedFileUrl(content.id);
       if (url) setOfflineUrl(url);
     };

--- a/components/library.tsx
+++ b/components/library.tsx
@@ -8,6 +8,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import {
+  saveContent,
+  getCachedContent,
+  cacheFileForContent,
+  removeCachedContent,
+} from "@/lib/offline-cache";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -127,7 +133,6 @@ export function Library({
             setContent(result.data)
             setTotalCount(result.total)
             try {
-              const { saveContent } = await import('../lib/offline-cache')
               await saveContent(result.data)
             } catch (err) {
               console.error('Failed to cache offline content', err)
@@ -138,7 +143,6 @@ export function Library({
         if (!cancelled) {
           console.error('Failed to load content:', error)
           try {
-            const { getCachedContent } = await import('../lib/offline-cache')
             const cached = await getCachedContent()
             if (cached.length > 0) {
               setContent(cached)
@@ -236,7 +240,6 @@ export function Library({
 
   const handleDownloadContent = async (content: any) => {
     try {
-      const { cacheFileForContent } = await import('../lib/offline-cache')
       await cacheFileForContent(content)
       toast.success('Content cached for offline use')
     } catch (err) {
@@ -252,7 +255,6 @@ export function Library({
     try {
       await deleteContent(contentToDelete.id);
       try {
-        const { removeCachedContent } = await import('../lib/offline-cache')
         await removeCachedContent(contentToDelete.id)
       } catch (err) {
         console.error('Failed to remove cached content', err)
@@ -267,7 +269,6 @@ export function Library({
       setContent(data);
       setTotalCount(total);
       try {
-        const { saveContent } = await import('../lib/offline-cache')
         await saveContent(data)
       } catch (err) {
         console.error('Failed to cache offline content', err)

--- a/components/performance-mode.tsx
+++ b/components/performance-mode.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useRef, useMemo } from "react"
+import { getCachedFileUrl } from "@/lib/offline-cache"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -72,7 +73,6 @@ export function PerformanceMode({
   useEffect(() => {
     let toRevoke: string[] = []
     const load = async () => {
-      const { getCachedFileUrl } = await import('../lib/offline-cache')
       const urls = await Promise.all(
         songs.map(async (song: any) => {
           const cached = song?.id ? await getCachedFileUrl(song.id) : null

--- a/components/setlist-manager.tsx
+++ b/components/setlist-manager.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { saveSetlists, removeCachedSetlist } from "@/lib/offline-setlist-cache"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -85,7 +86,6 @@ export function SetlistManager({ onEnterPerformance }: SetlistManagerProps) {
       console.log("Loaded content:", contentData)
 
       try {
-        const { saveSetlists } = await import('../lib/offline-setlist-cache')
         await saveSetlists(setlistsData as any[])
       } catch (err) {
         console.error('Failed to cache offline setlists', err)
@@ -136,7 +136,6 @@ export function SetlistManager({ onEnterPerformance }: SetlistManagerProps) {
       const updated = [setlistWithSongs, ...setlists]
       setSetlists(updated)
       try {
-        const { saveSetlists } = await import('../lib/offline-setlist-cache')
         await saveSetlists(updated as any[])
       } catch (err) {
         console.error('Failed to cache offline setlists', err)
@@ -153,7 +152,6 @@ export function SetlistManager({ onEnterPerformance }: SetlistManagerProps) {
     try {
       await deleteSetlist(setlistId)
       try {
-        const { removeCachedSetlist } = await import('../lib/offline-setlist-cache')
         await removeCachedSetlist(setlistId)
       } catch (err) {
         console.error('Failed to remove cached setlist', err)
@@ -161,7 +159,6 @@ export function SetlistManager({ onEnterPerformance }: SetlistManagerProps) {
       const updated = setlists.filter((s) => s.id !== setlistId)
       setSetlists(updated)
       try {
-        const { saveSetlists } = await import('../lib/offline-setlist-cache')
         await saveSetlists(updated as any[])
       } catch (err) {
         console.error('Failed to cache offline setlists', err)

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -4,6 +4,8 @@ import type React from "react"
 import { createContext, useContext, useEffect, useState, useCallback } from "react"
 import type { User, AuthChangeEvent, Session } from "@supabase/supabase-js"
 import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
+import { clearOfflineContent } from "@/lib/offline-cache"
+import { clearOfflineSetlists } from "@/lib/offline-setlist-cache"
 
 type Profile = {
   id: string
@@ -333,8 +335,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await supabase.auth.signOut()
 
       try {
-        const { clearOfflineContent } = await import("../lib/offline-cache")
-        const { clearOfflineSetlists } = await import("../lib/offline-setlist-cache")
         await Promise.all([
           clearOfflineContent(uid),
           clearOfflineSetlists(uid),


### PR DESCRIPTION
## Summary
- statically import offline cache modules so they are bundled for offline use

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68554fd3b24c8329924563df3a9ad6a0