### PR TITLE
Refactor content services into shared layer

### DIFF
--- a/lib/__tests__/content-service-server.test.ts
+++ b/lib/__tests__/content-service-server.test.ts
@@ -16,9 +16,12 @@ describe('getUserContentServer', () => {
     expect(getUserContent).toHaveBeenCalled()
     expect(res).toEqual(['demo'])
     vi.resetModules()
+    vi.doUnmock('../content-service')
+    vi.doUnmock('../supabase')
   })
 
   it('returns empty array when user not authenticated', async () => {
+    vi.doUnmock('../content-service')
     const mockClient = {
       auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }) },
       from: vi.fn(),
@@ -29,6 +32,8 @@ describe('getUserContentServer', () => {
     const res = await getUserContentServer()
     expect(res).toEqual([])
     vi.resetModules()
+    vi.doUnmock('../supabase')
+    vi.doUnmock('../supabase-server')
   })
 })
 
@@ -56,5 +61,7 @@ describe('getSetlistByIdServer', () => {
     expect(getSetlistById).toHaveBeenCalledWith('mock')
     expect(res).toEqual({ id: 'mock' })
     vi.resetModules()
+    vi.doUnmock('../supabase')
+    vi.doUnmock('../setlist-service')
   })
 })

--- a/lib/content-service-server.ts
+++ b/lib/content-service-server.ts
@@ -6,37 +6,16 @@ import {
   getContentById,
   getUserStats,
   getUserContentPage,
-  ContentQueryParams,
 } from "@/lib/content-service";
+import type { ContentQueryParams } from "@/lib/content-types";
 import { getSetlistById } from "@/lib/setlist-service";
 
 export async function getUserContentServer() {
   if (!isSupabaseConfigured) {
     return getUserContent();
   }
-
   const supabase = await getSupabaseServerClient();
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (authError || !user) {
-    return [];
-  }
-
-  const { data, error } = await supabase
-    .from("content")
-    .select("*")
-    .eq("user_id", user.id)
-    .order("created_at", { ascending: false });
-
-  if (error) {
-    logger.error("Error fetching content:", error);
-    return [];
-  }
-
-  return data || [];
+  return getUserContent(supabase);
 }
 
 export async function getUserContentPageServer(params: ContentQueryParams) {
@@ -44,142 +23,24 @@ export async function getUserContentPageServer(params: ContentQueryParams) {
     // reuse browser implementation in demo mode
     return getUserContentPage(params)
   }
-
-  const { page = 1, pageSize = 20, search = "", sortBy = "recent", filters = {} } =
-    params || {}
-
   const supabase = await getSupabaseServerClient()
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser()
-
-  if (authError || !user) {
-    return { data: [], total: 0 }
-  }
-
-  let query = supabase
-    .from("content")
-    .select("*", { count: "exact" })
-    .eq("user_id", user.id)
-
-  if (search) {
-    query = query.or(
-      `title.ilike.%${search}%,artist.ilike.%${search}%,album.ilike.%${search}%`,
-    )
-  }
-  if (filters.contentType?.length) {
-    query = query.in("content_type", filters.contentType)
-  }
-  if (filters.difficulty?.length) {
-    query = query.in("difficulty", filters.difficulty)
-  }
-  if (filters.key?.length) {
-    query = query.in("key", filters.key)
-  }
-  if (filters.favorite) {
-    query = query.eq("is_favorite", true)
-  }
-
-  if (sortBy === "recent") {
-    query = query.order("created_at", { ascending: false })
-  } else if (sortBy === "title") {
-    query = query.order("title", { ascending: true })
-  } else if (sortBy === "artist") {
-    query = query.order("artist", { ascending: true })
-  }
-
-  const from = (page - 1) * pageSize
-  const to = from + pageSize - 1
-  const { data, error, count } = await query.range(from, to)
-
-  if (error) {
-    logger.error("Error fetching content:", error)
-    return { data: [], total: 0 }
-  }
-
-  return { data: data || [], total: count || 0 }
+  return getUserContentPage(params, supabase)
 }
 
 export async function getContentByIdServer(id: string) {
   if (!isSupabaseConfigured) {
     return getContentById(id);
   }
-
   const supabase = await getSupabaseServerClient();
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (authError || !user) {
-    throw new Error("User not authenticated");
-  }
-
-  const { data, error } = await supabase
-    .from("content")
-    .select("*")
-    .eq("id", id)
-    .eq("user_id", user.id)
-    .single();
-
-  if (error) {
-    throw error;
-  }
-
-  return data;
+  return getContentById(id, supabase);
 }
 
 export async function getUserStatsServer() {
   if (!isSupabaseConfigured) {
     return getUserStats();
   }
-
   const supabase = await getSupabaseServerClient();
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (authError || !user) {
-    return {
-      totalContent: 0,
-      totalSetlists: 0,
-      favoriteContent: 0,
-      recentlyViewed: 0,
-    };
-  }
-
-  const { count: totalContent } = await supabase
-    .from("content")
-    .select("*", { count: "exact", head: true })
-    .eq("user_id", user.id);
-
-  const { count: favoriteContent } = await supabase
-    .from("content")
-    .select("*", { count: "exact", head: true })
-    .eq("user_id", user.id)
-    .eq("is_favorite", true);
-
-  let totalSetlists = 0;
-  try {
-    const { count } = await supabase
-      .from("setlists")
-      .select("*", { count: "exact", head: true })
-      .eq("user_id", user.id);
-    totalSetlists = count || 0;
-  } catch {
-    totalSetlists = 0;
-  }
-
-  const recentlyViewed = Math.min(totalContent || 0, 10);
-
-  return {
-    totalContent: totalContent || 0,
-    totalSetlists,
-    favoriteContent: favoriteContent || 0,
-    recentlyViewed,
-  };
+  return getUserStats(supabase);
 }
 
 export async function getSetlistByIdServer(id: string) {

--- a/lib/content-types.ts
+++ b/lib/content-types.ts
@@ -1,0 +1,13 @@
+export interface ContentQueryParams {
+  page?: number
+  pageSize?: number
+  search?: string
+  sortBy?: "recent" | "title" | "artist" | "updated"
+  useCache?: boolean
+  filters?: {
+    contentType?: string[]
+    difficulty?: string[]
+    key?: string[]
+    favorite?: boolean
+  }
+}


### PR DESCRIPTION
## Summary
- add `content-types` for shared query params
- refactor `content-service` to accept optional Supabase client
- simplify `content-service-server` by reusing browser logic
- adjust tests for updated mocks

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6855536c388883298d8512910f283d81