### PR TITLE
Fix offline caching of large files

### DIFF
--- a/lib/__tests__/offline-cache.test.ts
+++ b/lib/__tests__/offline-cache.test.ts
@@ -53,4 +53,18 @@ describe('offline cache', () => {
     const url = await cache.getCachedFileUrl('1')
     expect(url).toBeNull()
   })
+
+  it('skips caching when file exceeds quota', async () => {
+    const big = new Uint8Array(50 * 1024 * 1024 + 1)
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => big,
+      headers: { get: () => 'application/pdf' }
+    })) as any
+    await cache.cacheFilesForContent([
+      { id: 'big', file_url: 'https://x.test/big.pdf' }
+    ])
+    const url = await cache.getCachedFileUrl('big')
+    expect(url).toBeNull()
+  })
 })

--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -1,5 +1,6 @@
 import localforage from 'localforage'
 import { getSupabaseBrowserClient } from './supabase'
+import { toast } from '@/hooks/use-toast'
 
 const FILE_PREFIX = 'octavia-offline-file'
 
@@ -126,6 +127,13 @@ export async function cacheFilesForContent(items: any[]): Promise<void> {
           throw new Error(text || 'fetch failed')
         }
         const array = await res.arrayBuffer()
+        if (array.byteLength > MAX_CACHE_BYTES) {
+          toast({
+            title: 'File too large to cache',
+            description: 'This file exceeds the 50MB offline cache limit.'
+          })
+          continue
+        }
         const mime = res.headers.get('Content-Type') || 'application/octet-stream'
         await localforage.setItem(key, { mime, data: array })
         const size = array.byteLength


### PR DESCRIPTION
## Summary
- warn users when a file exceeds the offline cache limit
- don't store files larger than 50MB
- test oversized file caching behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556e4fa33083299c5467a68cdb61b0