### PR TITLE
Fix long-lived toasts

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- decrease `TOAST_REMOVE_DELAY` from ~16 minutes to 5 seconds

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855a1df5fac8329bcdac6a406bd791e