### PR TITLE
Fix lyrics loading from setlists

### DIFF
--- a/lib/content-service-server.ts
+++ b/lib/content-service-server.ts
@@ -84,7 +84,9 @@ export async function getSetlistByIdServer(id: string) {
           artist,
           content_type,
           key,
-          bpm
+          bpm,
+          file_url,
+          content_data
         )
       `,
     )
@@ -109,6 +111,8 @@ export async function getSetlistByIdServer(id: string) {
       content_type: song.content?.content_type || "Unknown Type",
       key: song.content?.key || null,
       bpm: song.content?.bpm || null,
+      file_url: song.content?.file_url || null,
+      content_data: song.content?.content_data || null,
     },
   }));
 


### PR DESCRIPTION
## Summary
- fetch full content data when querying setlist songs server-side
- include file url and content JSON when building setlist song objects
- populate mock setlists with complete content information

## Testing
- `pnpm exec next lint`
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6855c14e7cac832984abe7f9cb5d0636