### PR TITLE
Fix security issue in proxy endpoint

### DIFF
--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -69,6 +69,8 @@ export async function GET(req: NextRequest) {
       return new Response('Fetch failed', { status: res.status })
     }
     const headers = new Headers(res.headers)
+    headers.delete('set-cookie')
+    headers.delete('transfer-encoding')
     return new Response(res.body, { status: res.status, headers })
   } catch (err) {
     console.error('Proxy error', err)

--- a/lib/__tests__/proxy-endpoint.test.ts
+++ b/lib/__tests__/proxy-endpoint.test.ts
@@ -81,4 +81,28 @@ describe('proxy endpoint', () => {
     expect(res.status).toBe(200)
     expect((global.fetch as any).mock.calls[0][0]).toBe(allowedUrl)
   })
+
+  it('strips disallowed response headers', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://demo.supabase.co'
+    process.env.ALLOWED_PROXY_HOSTS = 'demo.supabase.co'
+
+    vi.doMock('../supabase-server', () => ({
+      getSupabaseServerClient: async () => ({
+        auth: {
+          getSession: vi.fn().mockResolvedValue({ data: { session: {} }, error: null })
+        }
+      })
+    }))
+
+    const upstreamHeaders = new Headers({ 'set-cookie': 'a=b', 'x-test': '1' })
+    global.fetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200, headers: upstreamHeaders })) as any
+
+    const { GET } = await import('../../app/api/proxy/route')
+    const allowedUrl = 'https://demo.supabase.co/storage/v1/object/file.txt'
+    const req = new NextRequest('https://site.test/api/proxy?url=' + encodeURIComponent(allowedUrl))
+    const res = await GET(req as any)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('set-cookie')).toBeNull()
+    expect(res.headers.get('x-test')).toBe('1')
+  })
 })


### PR DESCRIPTION
## Summary
- sanitize headers in `/api/proxy` by removing `set-cookie` and `transfer-encoding`
- add regression test ensuring these headers are stripped

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6855e4aec60883299e091500b3657db7