### PR TITLE
Fix searchParams typing for server pages

### DIFF
--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -6,7 +6,7 @@ import LibraryPageClient from "@/components/library-page-client";
 export default async function LibraryPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ [key: string]: string }>
+  searchParams?: { [key: string]: string | string[] | undefined }
 }) {
   const supabase = await getSupabaseServerClient();
   const {
@@ -17,9 +17,13 @@ export default async function LibraryPage({
     redirect("/login");
   }
 
-  const resolved = await searchParams;
-  const search = resolved?.search || "";
-  const page = resolved?.page ? parseInt(resolved.page, 10) : 1;
+  const searchParam = searchParams?.search;
+  const search = Array.isArray(searchParam)
+    ? searchParam[0]
+    : searchParam ?? "";
+
+  const pageParam = searchParams?.page;
+  const page = pageParam ? parseInt(Array.isArray(pageParam) ? pageParam[0] : pageParam, 10) : 1;
   const pageSize = 20;
   const { data, total } = await getUserContentPageServer({
     page,

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,7 +7,7 @@ import { Music } from "lucide-react"
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>
+  searchParams?: { [key: string]: string | string[] | undefined }
 }) {
   const supabase = await getSupabaseServerClient()
   const {
@@ -18,8 +18,7 @@ export default async function LoginPage({
     redirect("/dashboard")
   }
 
-  const resolvedSearchParams = await searchParams
-  const errorDescription = resolvedSearchParams?.error_description
+  const errorDescription = searchParams?.error_description
   const error = typeof errorDescription === "string" ? errorDescription : ""
 
   return (

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -9,7 +9,7 @@ import PerformancePageClient from "@/components/performance-page-client";
 export default async function PerformancePage({
   searchParams,
 }: {
-  searchParams?: Promise<{ [key: string]: string }>;
+  searchParams?: { [key: string]: string | string[] | undefined };
 }) {
   const supabase = await getSupabaseServerClient();
   const {
@@ -20,9 +20,8 @@ export default async function PerformancePage({
     redirect("/login");
   }
 
-  const resolvedSearchParams = await searchParams;
-  const contentId = resolvedSearchParams?.contentId;
-  const setlistId = resolvedSearchParams?.setlistId;
+  const contentId = searchParams?.contentId as string | undefined;
+  const setlistId = searchParams?.setlistId as string | undefined;
 
   let content: any | null = null;
   let setlist: any | null = null;


### PR DESCRIPTION
## Summary
- treat `searchParams` as plain object instead of a `Promise`
- update library, login, and performance pages accordingly

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6855ed87bd9c8329a486a91fe1a187ec