### PR TITLE
Fix content cache interval keeping process alive

### DIFF
--- a/lib/content-service.ts
+++ b/lib/content-service.ts
@@ -171,8 +171,8 @@ function cleanupCache() {
   }
 }
 
-// Clean cache every 5 minutes
-setInterval(cleanupCache, 5 * 60 * 1000)
+// Clean cache every 5 minutes without keeping the Node.js process alive
+setInterval(cleanupCache, 5 * 60 * 1000).unref()
 
 export async function getUserContentPage(
   params: ContentQueryParams = {},


### PR DESCRIPTION
## Summary
- ensure the content service's cache cleanup timer doesn't prevent process exit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855fdfab2a083298c135bd37ac842e9