### PR TITLE
Restore isSupabaseConfigured export

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,20 +1,91 @@
 import { createBrowserClient } from "@supabase/ssr"
+import logger from "@/lib/logger"
 import type { Database } from "@/types/supabase"
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+export const isSupabaseConfigured = Boolean(
+  supabaseUrl &&
+    supabaseAnonKey &&
+    supabaseUrl.startsWith("https://") &&
+    supabaseAnonKey.length > 20,
+)
+
+const createMockClient = () => ({
+  auth: {
+    getSession: () =>
+      Promise.resolve({
+        data: { session: null },
+        error: null,
+      }),
+    onAuthStateChange: (callback: any) => {
+      setTimeout(() => callback("INITIAL_SESSION", null), 0)
+      return {
+        data: {
+          subscription: {
+            unsubscribe: () =>
+              logger.log("Mock auth subscription unsubscribed"),
+          },
+        },
+      }
+    },
+    signInWithPassword: () =>
+      Promise.resolve({
+        data: { user: null, session: null },
+        error: { message: "Demo mode - authentication disabled" },
+      }),
+    signUp: () =>
+      Promise.resolve({
+        data: { user: null, session: null },
+        error: { message: "Demo mode - authentication disabled" },
+      }),
+    signOut: () => Promise.resolve({ error: null }),
+    getUser: () =>
+      Promise.resolve({
+        data: { user: null },
+        error: null,
+      }),
+  },
+  from: () => ({
+    select: () => ({
+      eq: () => ({
+        single: () => Promise.resolve({ data: null, error: null }),
+        limit: () => Promise.resolve({ data: [], error: null }),
+      }),
+      limit: () => Promise.resolve({ data: [], error: null }),
+      order: () => Promise.resolve({ data: [], error: null }),
+    }),
+    insert: () => Promise.resolve({ data: null, error: null }),
+    update: () => ({
+      eq: () => Promise.resolve({ data: null, error: null }),
+    }),
+    delete: () => ({
+      eq: () => Promise.resolve({ data: null, error: null }),
+    }),
+  }),
+})
 
 let supabaseBrowserClient: ReturnType<typeof createBrowserClient> | null = null
 
 export function getSupabaseBrowserClient() {
   if (!supabaseBrowserClient) {
-    supabaseBrowserClient = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey)
+    if (!isSupabaseConfigured) {
+      logger.warn("Supabase not configured - using mock client for demo mode")
+      supabaseBrowserClient = createMockClient() as any
+    } else {
+      supabaseBrowserClient = createBrowserClient<Database>(supabaseUrl!, supabaseAnonKey!)
+    }
   }
   return supabaseBrowserClient
 }
 
 // Test connection with comprehensive error handling
 export async function testSupabaseConnection(): Promise<boolean> {
+  if (!isSupabaseConfigured) {
+    return false
+  }
+
   try {
     const supabase = getSupabaseBrowserClient()
 
@@ -26,7 +97,8 @@ export async function testSupabaseConnection(): Promise<boolean> {
     }
 
     return !error
-  } catch {
+  } catch (error) {
+    logger.warn("Supabase connection test failed:", error)
     return false
   }
 }


### PR DESCRIPTION
## Summary
- restore `isSupabaseConfigured` flag and demo client logic in `lib/supabase.ts`
- fall back to a mock Supabase client when credentials aren't provided

## Testing
- `pnpm build`
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'auth'))*

------
https://chatgpt.com/codex/tasks/task_e_685623121214832988d91616dbb5a6d6