### PR TITLE
Add image sheet music display

### DIFF
--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -574,25 +574,33 @@ export function ContentViewer({
 
                               {offlineUrl || content.file_url ? (
                                 <div className="overflow-hidden bg-white/80 backdrop-blur-sm border border-orange-200 rounded-xl shadow">
-                                  {(offlineUrl || content.file_url)!.toLowerCase().endsWith(".pdf") ? (
-                                    <PdfViewer
-                                      url={(offlineUrl || content.file_url) as string}
-                                      fullscreen
-                                      className="w-full h-[calc(100vh-250px)]"
-                                    />
-                                  ) : (
-                                    <Image
-                                      src={(offlineUrl || content.file_url) || "/placeholder.svg"}
-                                      alt={`Sheet music for ${content.title}`}
-                                      width={800}
-                                      height={800}
-                                      className="w-full h-auto"
-                                      style={{
-                                        maxHeight: "calc(100vh - 250px)",
-                                        objectFit: "contain",
-                                      }}
-                                    />
-                                  )}
+                                  {(() => {
+                                    const url = (offlineUrl || content.file_url)!.toLowerCase()
+                                    const isPdf = url.endsWith(".pdf")
+                                    const isImage = url.endsWith(".png") || url.endsWith(".jpg") || url.endsWith(".jpeg")
+                                    if (isPdf) {
+                                      return (
+                                        <PdfViewer
+                                          url={(offlineUrl || content.file_url) as string}
+                                          fullscreen
+                                          className="w-full h-[calc(100vh-250px)]"
+                                        />
+                                      )
+                                    }
+                                    if (isImage) {
+                                      return (
+                                        <Image
+                                          src={(offlineUrl || content.file_url) as string}
+                                          alt={`Sheet music for ${content.title}`}
+                                          width={800}
+                                          height={800}
+                                          className="w-full h-auto"
+                                          style={{ maxHeight: "calc(100vh - 250px)", objectFit: "contain" }}
+                                        />
+                                      )
+                                    }
+                                    return null
+                                  })()}
                                 </div>
                               ) : content.content_data?.notation ? (
                                 <div className="p-6 bg-white/80 backdrop-blur-sm border border-orange-200 rounded-xl shadow">

--- a/components/editors/content-type-editor.tsx
+++ b/components/editors/content-type-editor.tsx
@@ -5,6 +5,7 @@ import { LyricsEditor } from "@/components/lyrics-editor"
 import { TabEditor } from "@/components/tab-editor"
 import { AnnotationTools } from "@/components/annotation-tools"
 import PdfViewer from "@/components/pdf-viewer"
+import Image from "next/image"
 import { ContentType } from "@/types/content"
 
 interface ContentTypeEditorProps {
@@ -45,14 +46,31 @@ export function ContentTypeEditor({ content, onChange }: ContentTypeEditorProps)
         />
       )
     case ContentType.SHEET_MUSIC:
-      if (content.file_url && content.file_url.toLowerCase().endsWith(".pdf")) {
-        return (
-          <PdfViewer
-            url={content.file_url}
-            className="w-full h-[calc(100vh-250px)]"
-            fullscreen
-          />
-        )
+      if (content.file_url) {
+        const url = content.file_url.toLowerCase()
+        if (url.endsWith(".pdf")) {
+          return (
+            <PdfViewer
+              url={content.file_url}
+              className="w-full h-[calc(100vh-250px)]"
+              fullscreen
+            />
+          )
+        }
+        if (url.endsWith(".png") || url.endsWith(".jpg") || url.endsWith(".jpeg")) {
+          return (
+            <div className="flex justify-center">
+              <Image
+                src={content.file_url}
+                alt="Sheet music"
+                width={800}
+                height={800}
+                className="w-full h-auto"
+                style={{ maxHeight: "calc(100vh - 250px)", objectFit: "contain" }}
+              />
+            </div>
+          )
+        }
       }
       return (
         <AnnotationTools

--- a/components/performance-mode.tsx
+++ b/components/performance-mode.tsx
@@ -369,22 +369,33 @@ export function PerformanceMode({
             <div className="space-y-8 max-w-3xl mx-auto">
               {currentSongData.content_type === ContentType.SHEET_MUSIC ? (
                 sheetUrls[currentSong] ? (
-                  sheetUrls[currentSong]!.toLowerCase().endsWith(".pdf") ? (
-                    <PdfViewer
-                      url={sheetUrls[currentSong] as string}
-                      fullscreen
-                      className="h-[calc(100vh-200px)]"
-                    />
-                  ) : (
-                    <Image
-                      src={sheetUrls[currentSong] as string}
-                      alt={currentSongData.title}
-                      width={800}
-                      height={800}
-                      className="w-full h-auto"
-                      style={{ maxHeight: "100%", objectFit: "contain" }}
-                    />
-                  )
+                  (() => {
+                    const url = sheetUrls[currentSong]!.toLowerCase()
+                    const isPdf = url.endsWith(".pdf")
+                    const isImage = url.endsWith(".png") || url.endsWith(".jpg") || url.endsWith(".jpeg")
+                    if (isPdf) {
+                      return (
+                        <PdfViewer
+                          url={sheetUrls[currentSong] as string}
+                          fullscreen
+                          className="h-[calc(100vh-200px)]"
+                        />
+                      )
+                    }
+                    if (isImage) {
+                      return (
+                        <Image
+                          src={sheetUrls[currentSong] as string}
+                          alt={currentSongData.title}
+                          width={800}
+                          height={800}
+                          className="w-full h-auto"
+                          style={{ maxHeight: "100%", objectFit: "contain" }}
+                        />
+                      )
+                    }
+                    return null
+                  })()
                 ) : (
                   <div className="text-center text-[#A69B8E] py-10">
                     <p className="text-xl">No sheet music available</p>


### PR DESCRIPTION
## Summary
- render uploaded sheet music images in the editor
- detect PDF vs image in content viewer
- handle images in performance mode

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856f9dc2f7483298a151a281abb3483