### PR TITLE
Fix offline cache size check

### DIFF
--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -126,6 +126,15 @@ export async function cacheFilesForContent(items: any[]): Promise<void> {
           const text = await res.text().catch(() => '')
           throw new Error(text || 'fetch failed')
         }
+        const lengthHeader = res.headers.get('Content-Length')
+        if (lengthHeader && Number(lengthHeader) > MAX_CACHE_BYTES) {
+          toast({
+            title: 'File too large to cache',
+            description: 'This file exceeds the 50MB offline cache limit.'
+          })
+          res.body?.cancel?.()
+          continue
+        }
         const array = await res.arrayBuffer()
         if (array.byteLength > MAX_CACHE_BYTES) {
           toast({


### PR DESCRIPTION
## Summary
- prevent large file downloads by checking `Content-Length` before calling `arrayBuffer()`
- test that large files are skipped without downloading

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68576dab8c488329b6417b3a7c6a6b3b