### PR TITLE
Fix Supabase auth session handling

### DIFF
--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -1,5 +1,5 @@
 import localforage from 'localforage'
-import { getSupabaseBrowserClient } from './supabase'
+import { getSupabaseBrowserClient, getSessionSafe } from './supabase'
 import { toast } from '@/hooks/use-toast'
 
 const FILE_PREFIX = 'octavia-offline-file'
@@ -22,8 +22,8 @@ function encodeBase64(data: Uint8Array): string {
 async function getUserId(): Promise<string | null> {
   try {
     const supabase = getSupabaseBrowserClient()
-    const { data } = await supabase.auth.getSession()
-    return data.session?.user?.id || null
+    const session = await getSessionSafe()
+    return session?.user?.id || null
   } catch {
     return null
   }

--- a/lib/offline-setlist-cache.ts
+++ b/lib/offline-setlist-cache.ts
@@ -1,13 +1,13 @@
 import localforage from 'localforage'
-import { getSupabaseBrowserClient } from './supabase'
+import { getSupabaseBrowserClient, getSessionSafe } from './supabase'
 
 const STORE_KEY_BASE = 'octavia-offline-setlists'
 
 async function getUserId(): Promise<string | null> {
   try {
     const supabase = getSupabaseBrowserClient()
-    const { data } = await supabase.auth.getSession()
-    return data.session?.user?.id || null
+    const session = await getSessionSafe()
+    return session?.user?.id || null
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- use `@supabase/supabase-js` browser client
- add `getSessionSafe` helper
- refresh auth on visibility changes and storage events
- update offline-cache utilities to use new helper
- update services to rely on `getSessionSafe`

## Testing
- `pnpm run lint`
- `pnpm test` *(fails: Session retrieval mock issues)*

------
https://chatgpt.com/codex/tasks/task_e_685879d48430832993b9fb487b25f60d