### PR TITLE
Improve supabase client setup

### DIFF
--- a/contexts/__tests__/auth-context.test.tsx
+++ b/contexts/__tests__/auth-context.test.tsx
@@ -52,6 +52,7 @@ describe('AuthProvider', () => {
     vi.doMock('@/lib/supabase', () => ({
       isSupabaseConfigured: true,
       getSupabaseBrowserClient: () => mockClient,
+      getSessionSafe: vi.fn().mockResolvedValue(null),
     }))
     const mod = await import('../auth-context')
     const wrapper = ({ children }: any) => <mod.AuthProvider>{children}</mod.AuthProvider>

--- a/lib/__tests__/content-service.test.ts
+++ b/lib/__tests__/content-service.test.ts
@@ -33,6 +33,7 @@ describe('Content Service', () => {
       vi.doMock('../supabase', () => ({
         isSupabaseConfigured: true,
         getSupabaseBrowserClient: () => mockClient,
+        getSessionSafe: vi.fn().mockResolvedValue(null),
       }))
       const { getUserContent } = await import('../content-service')
       const data = await getUserContent()
@@ -65,6 +66,7 @@ describe('Content Service', () => {
       vi.doMock('../supabase', () => ({
         isSupabaseConfigured: true,
         getSupabaseBrowserClient: () => mockClient,
+        getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
       }))
       const { getUserContent } = await import('../content-service')
       const data = await getUserContent()
@@ -104,6 +106,7 @@ describe('Content Service', () => {
         vi.doMock('../supabase', () => ({
           isSupabaseConfigured: true,
           getSupabaseBrowserClient: () => mockClient,
+          getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
         const { getUserContentPage } = await import('../content-service')
@@ -155,6 +158,7 @@ describe('Content Service', () => {
         vi.doMock('../supabase', () => ({
           isSupabaseConfigured: true,
           getSupabaseBrowserClient: () => mockClient,
+          getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
         const { getUserContentPage } = await import('../content-service')
@@ -176,6 +180,7 @@ describe('Content Service', () => {
         vi.doMock('../supabase', () => ({
           isSupabaseConfigured: true,
           getSupabaseBrowserClient: () => mockClient,
+          getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
         const { getUserContentPage } = await import('../content-service')
@@ -212,6 +217,7 @@ describe('Content Service', () => {
          vi.doMock('../supabase', () => ({
            isSupabaseConfigured: true,
            getSupabaseBrowserClient: () => mockClient,
+           getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
          }))
 
          const { getUserContentPage } = await import('../content-service')
@@ -265,6 +271,7 @@ describe('Content Service', () => {
           vi.doMock('../supabase', () => ({
             isSupabaseConfigured: true,
             getSupabaseBrowserClient: () => mockClient,
+            getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
           }))
 
           const { getUserContentPage } = await import('../content-service')
@@ -303,6 +310,7 @@ describe('Content Service', () => {
         vi.doMock('../supabase', () => ({
           isSupabaseConfigured: true,
           getSupabaseBrowserClient: () => mockClient,
+          getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
         const { getUserContentPage } = await import('../content-service')
@@ -351,6 +359,7 @@ describe('Content Service', () => {
         vi.doMock('../supabase', () => ({
           isSupabaseConfigured: true,
           getSupabaseBrowserClient: () => mockClient,
+          getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
         const { getUserContentPage } = await import('../content-service')
@@ -399,6 +408,7 @@ describe('Content Service', () => {
         vi.doMock('../supabase', () => ({
           isSupabaseConfigured: true,
           getSupabaseBrowserClient: () => mockClient,
+          getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
         const { getUserContentPage } = await import('../content-service')

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js"
+import { createBrowserClient } from "@supabase/ssr"
 import logger from "@/lib/logger"
 import type { Database } from "@/types/supabase"
 
@@ -66,7 +66,7 @@ const createMockClient = () => ({
   }),
 })
 
-let supabaseBrowserClient: ReturnType<typeof createClient> | null = null
+let supabaseBrowserClient: ReturnType<typeof createBrowserClient> | null = null
 
 export function getSupabaseBrowserClient() {
   if (!supabaseBrowserClient) {
@@ -74,11 +74,11 @@ export function getSupabaseBrowserClient() {
       logger.warn("Supabase not configured - using mock client for demo mode")
       supabaseBrowserClient = createMockClient() as any
     } else {
-      supabaseBrowserClient = createClient<Database>(supabaseUrl!, supabaseAnonKey!, {
+      supabaseBrowserClient = createBrowserClient<Database>(supabaseUrl!, supabaseAnonKey!, {
+        isSingleton: true,
         auth: {
           persistSession: true,
           autoRefreshToken: true,
-          detectSessionInUrl: true,
         },
       })
     }


### PR DESCRIPTION
## Summary
- replace direct `createClient` usage with `createBrowserClient`
- update tests to mock `getSessionSafe`

## Testing
- `pnpm test` *(fails: expected "spy" to be called 3 times, but got 0 times)*

------
https://chatgpt.com/codex/tasks/task_e_6858720d32ac8329a23d7180b3b10bb7