### PR TITLE
Fix login and signup auth checks

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,21 +1,13 @@
 import Image from "next/image"
 import { redirect } from "next/navigation"
-import { getSupabaseServerClient } from "@/lib/supabase-server"
-import { isSupabaseConfigured } from "@/lib/supabase"
+import { getServerSideUser } from "@/lib/firebase-server-utils"
 import { LoginPanel } from "@/components/auth/login-panel"
 import { Music } from "lucide-react"
 
 export default async function LoginPage({ searchParams }: { searchParams?: Promise<any> }) {
-  let session = null
-  if (isSupabaseConfigured) {
-    const supabase = await getSupabaseServerClient()
-    const {
-      data: { session: supabaseSession },
-    } = await supabase.auth.getSession()
-    session = supabaseSession
-  }
+  const user = await getServerSideUser()
 
-  if (session) {
+  if (user) {
     redirect("/dashboard")
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,13 @@
 import { redirect } from "next/navigation"
-import { getSupabaseServerClient } from "@/lib/supabase-server"
-import { isSupabaseConfigured } from "@/lib/supabase"
+import { getServerSideUser } from "@/lib/firebase-server-utils"
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
 import Link from "next/link"
 import { Music, FileText, Guitar, Users } from "lucide-react"
 
 export default async function LandingPage() {
-  let session = null
-  if (isSupabaseConfigured) {
-    const supabase = await getSupabaseServerClient()
-    const {
-      data: { session: supabaseSession },
-    } = await supabase.auth.getSession()
-    session = supabaseSession
-  }
-  if (session) {
+  const user = await getServerSideUser()
+  if (user) {
     redirect("/dashboard")
   }
 

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,21 +1,13 @@
 import Image from "next/image"
 import { redirect } from "next/navigation"
-import { getSupabaseServerClient } from "@/lib/supabase-server"
-import { isSupabaseConfigured } from "@/lib/supabase"
+import { getServerSideUser } from "@/lib/firebase-server-utils"
 import { SignupPanel } from "@/components/auth/signup-panel"
 import { Music } from "lucide-react"
 
 export default async function SignupPage() {
-  let session = null
-  if (isSupabaseConfigured) {
-    const supabase = await getSupabaseServerClient()
-    const {
-      data: { session: supabaseSession },
-    } = await supabase.auth.getSession()
-    session = supabaseSession
-  }
+  const user = await getServerSideUser()
 
-  if (session) {
+  if (user) {
     redirect("/dashboard")
   }
 


### PR DESCRIPTION
## Summary
- remove Supabase auth logic from `app/page.tsx`, `app/login/page.tsx`, and `app/signup/page.tsx`
- rely on `getServerSideUser` for Firebase-based redirects

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6859945af34483298c87b1955336f6e8