### PR TITLE
Automatic offline caching for viewed content

### DIFF
--- a/app/_offline/page.tsx
+++ b/app/_offline/page.tsx
@@ -57,7 +57,7 @@ export default function OfflinePage() {
           </CardHeader>
           <CardContent className="text-center space-y-4">
             <p className="text-amber-700">
-              No internet connection detected. Some features may be limited, but you can still access your cached content.
+              No internet connection detected. Some features may be limited, but recently opened files are cached for offline access.
             </p>
             
             <Button 
@@ -148,7 +148,7 @@ export default function OfflinePage() {
             <ul className="space-y-2 text-amber-700">
               <li className="flex items-center">
                 <div className="w-2 h-2 bg-amber-600 rounded-full mr-3"></div>
-                View cached sheet music and lyrics
+                View automatically cached sheet music and lyrics
               </li>
               <li className="flex items-center">
                 <div className="w-2 h-2 bg-amber-600 rounded-full mr-3"></div>

--- a/components/content-edit-page-client.tsx
+++ b/components/content-edit-page-client.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import type { Database } from "@/types/supabase";
 import dynamic from "next/dynamic";
@@ -8,6 +8,7 @@ import { Header } from "@/components/header";
 import { cn } from "@/lib/utils";
 import { updateContent } from "@/lib/content-service";
 import { toast } from "sonner";
+import { cacheFileForContent } from "@/lib/offline-cache";
 
 const ContentEditor = dynamic(() => import("@/components/content-editor").then(mod => ({ default: mod.ContentEditor })), {
   loading: () => <p>Loading editor...</p>,
@@ -24,6 +25,13 @@ export default function ContentEditPageClient({ content }: ContentEditPageClient
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeScreen, setActiveScreen] = useState("library");
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
+
+  useEffect(() => {
+    if (!content) return
+    cacheFileForContent(content).catch(err => {
+      console.error('Failed to cache file for content', err)
+    })
+  }, [content])
 
   const handleNavigate = (screen: string) => {
     router.push(`/${screen}`);

--- a/components/content-page-client.tsx
+++ b/components/content-page-client.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import type { Database } from "@/types/supabase";
 import { ContentViewer } from "@/components/content-viewer";
+import { cacheFileForContent } from "@/lib/offline-cache";
 import { Sidebar } from "@/components/sidebar";
 import { Header } from "@/components/header";
 import dynamic from "next/dynamic";
@@ -29,6 +30,13 @@ export default function ContentPageClient({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeScreen, setActiveScreen] = useState("library");
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
+
+  useEffect(() => {
+    if (!initialContent) return
+    cacheFileForContent(initialContent).catch(err => {
+      console.error('Failed to cache file for content', err)
+    })
+  }, [initialContent])
 
   const handleNavigate = (screen: string) => {
     router.push(`/${screen}`);

--- a/components/performance-mode.tsx
+++ b/components/performance-mode.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from "react"
 import { toast } from "sonner"
-import { getCachedFileUrl } from "@/lib/offline-cache"
+import { getCachedFileUrl, cacheFilesForContent } from "@/lib/offline-cache"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -92,6 +92,12 @@ export function PerformanceMode({
     return () => {
       toRevoke.forEach(url => URL.revokeObjectURL(url))
     }
+  }, [songs])
+
+  useEffect(() => {
+    cacheFilesForContent(songs).catch(err => {
+      console.error('Failed to cache files for performance', err)
+    })
   }, [songs])
 
   const toggleFullScreen = () => {


### PR DESCRIPTION
## Summary
- cache files for opened content and editing mode
- cache setlist song files in performance mode
- clarify offline page messaging about automatic caching

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6859a8bd95048329a001abfbea5d1945