### PR TITLE
Remove content length dependency

### DIFF
--- a/components/library.tsx
+++ b/components/library.tsx
@@ -253,7 +253,9 @@ export function Library({
         clearTimeout(fetchTimeoutId)
       }
     }
-  }, [debouncedSearch, sortBy, selectedFilters, page, pageSize, refreshTrigger, content.length, initialPage, initialPageSize, initialSearch, user, authLoading])
+  // We intentionally exclude `content.length` to avoid unnecessary refetches when content changes locally
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch, sortBy, selectedFilters, page, pageSize, refreshTrigger, initialPage, initialPageSize, initialSearch, user, authLoading])
 
   // Add focus listener to refresh data when returning to the library with improved throttling
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid including `content.length` in the main library fetching effect
- document why the dependency is intentionally omitted

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6859b645c920832993e1889a8a405206