### PR TITLE
Add server-side Firebase auth validation

### DIFF
--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -20,5 +20,66 @@ describe('middleware auth', () => {
     const res = await middleware(req as any)
 
     expect(res.headers.get('location')).toBe('https://site.test/login')
+    vi.resetModules()
+  })
+
+  it('allows request when session cookie is valid', async () => {
+    vi.doMock('../firebase-server-utils', () => ({
+      validateFirebaseTokenServer: vi.fn().mockResolvedValue({ isValid: true })
+    }))
+
+    vi.spyOn(NextResponse, 'next').mockImplementation(() => new NextResponse())
+
+    const { middleware } = await import('../../middleware')
+
+    const baseReq = new Request('https://site.test/dashboard', {
+      headers: new Headers({ cookie: 'firebase-session=valid' })
+    })
+    const req = new NextRequest(baseReq)
+
+    const res = await middleware(req as any)
+
+    expect(res.headers.get('location')).toBeNull()
+    vi.resetModules()
+  })
+
+  it('redirects to login when bearer token is invalid', async () => {
+    vi.doMock('../firebase-server-utils', () => ({
+      validateFirebaseTokenServer: vi.fn().mockResolvedValue({ isValid: false })
+    }))
+
+    vi.spyOn(NextResponse, 'next').mockImplementation(() => new NextResponse())
+
+    const { middleware } = await import('../../middleware')
+
+    const baseReq = new Request('https://site.test/dashboard', {
+      headers: new Headers({ authorization: 'Bearer badtoken' })
+    })
+    const req = new NextRequest(baseReq)
+
+    const res = await middleware(req as any)
+
+    expect(res.headers.get('location')).toBe('https://site.test/login')
+    vi.resetModules()
+  })
+
+  it('allows request when bearer token is valid', async () => {
+    vi.doMock('../firebase-server-utils', () => ({
+      validateFirebaseTokenServer: vi.fn().mockResolvedValue({ isValid: true })
+    }))
+
+    vi.spyOn(NextResponse, 'next').mockImplementation(() => new NextResponse())
+
+    const { middleware } = await import('../../middleware')
+
+    const baseReq = new Request('https://site.test/dashboard', {
+      headers: new Headers({ authorization: 'Bearer goodtoken' })
+    })
+    const req = new NextRequest(baseReq)
+
+    const res = await middleware(req as any)
+
+    expect(res.headers.get('location')).toBeNull()
+    vi.resetModules()
   })
 })


### PR DESCRIPTION
## Summary
- validate bearer tokens or firebase-session cookies with `validateFirebaseTokenServer`
- test middleware for valid and invalid tokens

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c1bcc9f4832986af272f4e3c9741