### PR TITLE
Refactor auth usage to Firebase

### DIFF
--- a/lib/__tests__/content-service.test.ts
+++ b/lib/__tests__/content-service.test.ts
@@ -161,11 +161,14 @@ describe('Content Service', () => {
           getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
+        vi.doMock('../firebase', () => ({
+          auth: { currentUser: { uid: 'user1', email: 'test@example.com' } }
+        }))
+
         const { getUserContentPage } = await import('../content-service')
-        
+
         const result = await getUserContentPage()
-        
-        expect(mockClient.auth.getUser).toHaveBeenCalledTimes(3)
+
         expect(result.data).toEqual([])
         vi.resetModules()
       })
@@ -183,10 +186,13 @@ describe('Content Service', () => {
           getSessionSafe: vi.fn().mockResolvedValue({ user: { id: 'user1' } }),
         }))
 
+        vi.doMock('../firebase', () => ({
+          auth: null
+        }))
+
         const { getUserContentPage } = await import('../content-service')
-        
-        await expect(getUserContentPage()).rejects.toThrow('Authentication failed. Please log in again.')
-        expect(mockClient.auth.getUser).toHaveBeenCalledTimes(3)
+
+        await expect(getUserContentPage()).rejects.toThrow('User not authenticated')
         vi.resetModules()
       })
 

--- a/lib/__tests__/storage-service.test.ts
+++ b/lib/__tests__/storage-service.test.ts
@@ -4,18 +4,15 @@ it('uploads file when Supabase configured', async () => {
   const upload = vi.fn().mockResolvedValue({ error: null })
   const getPublicUrl = vi.fn(() => ({ data: { publicUrl: 'https://bucket/test' } }))
   const from = vi.fn(() => ({ upload, getPublicUrl }))
-  const client = { 
-    storage: { from },
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ 
-        data: { user: { id: 'user1', email: 'test@example.com' } }, 
-        error: null 
-      })
-    }
+  const client = {
+    storage: { from }
   }
   vi.doMock('../supabase', () => ({
     isSupabaseConfigured: true,
     getSupabaseBrowserClient: () => client
+  }))
+  vi.doMock('../firebase', () => ({
+    auth: { currentUser: { uid: 'user1', email: 'test@example.com' } }
   }))
   const { uploadFileToStorage } = await import('../storage-service')
   const res = await uploadFileToStorage(new Blob(['a']), 'test.pdf')

--- a/lib/content-service-server.ts
+++ b/lib/content-service-server.ts
@@ -117,21 +117,18 @@ export async function getSetlistByIdServer(id: string) {
     return getSetlistById(id);
   }
 
-  const supabase = await getSupabaseServerClient();
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (authError || !user) {
+  const firebaseUser = await getServerSideUser();
+  if (!firebaseUser) {
     throw new Error("User not authenticated");
   }
+
+  const supabase = await getSupabaseServerClient();
 
   const { data: setlist, error: setlistError } = await supabase
     .from("setlists")
     .select("*")
     .eq("id", id)
-    .eq("user_id", user.id)
+    .eq("user_id", firebaseUser.uid)
     .single();
 
   if (setlistError) {

--- a/lib/setlist-service.ts
+++ b/lib/setlist-service.ts
@@ -1,29 +1,15 @@
-import { getSupabaseBrowserClient, isSupabaseConfigured, getSessionSafe } from "@/lib/supabase"
+import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
 import logger from "@/lib/logger"
 import { getContentById } from "@/lib/content-service"
+import { auth } from "@/lib/firebase"
 import type { Database } from "@/types/supabase"
 
-// Helper function to get authenticated user with improved session handling
-async function getAuthenticatedUser(supabase: any): Promise<any | null> {
-  console.log("🔍 setlist-service getAuthenticatedUser: Starting auth check...")
-  
-  try {
-    const session = await getSessionSafe(2000)
-    if (session?.user) {
-      console.log(`🔍 setlist-service: Session valid! User: ${session.user.email}`)
-      return session.user
-    }
-    console.log("🔍 setlist-service: No valid session found")
-    return null
-    
-  } catch (error) {
-    if (error instanceof Error && error.message === 'Auth check timeout') {
-      console.log("🔍 setlist-service: Auth check timed out")
-    } else {
-      console.log("🔍 setlist-service: Auth check failed:", error)
-    }
-    return null
+// Helper to get the current Firebase user
+function getAuthenticatedUser() {
+  if (auth && auth.currentUser) {
+    return { id: auth.currentUser.uid, email: auth.currentUser.email }
   }
+  return null
 }
 
 // Mock data for demo mode
@@ -253,12 +239,8 @@ export async function getSetlistById(id: string) {
 
     const supabase = getSupabaseBrowserClient()
 
-    // Check if user is authenticated
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
+    const user = getAuthenticatedUser()
+    if (!user) {
       throw new Error("User not authenticated")
     }
 
@@ -357,11 +339,8 @@ export async function createSetlist(setlist: { name: string; description?: strin
     const supabase = getSupabaseBrowserClient()
 
     // Check if user is authenticated
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
+    const user = getAuthenticatedUser()
+    if (!user) {
       throw new Error("User not authenticated")
     }
 
@@ -418,12 +397,8 @@ export async function updateSetlist(id: string, updates: { name?: string; descri
 
     const supabase = getSupabaseBrowserClient()
 
-    // Check if user is authenticated
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
+    const user = getAuthenticatedUser()
+    if (!user) {
       throw new Error("User not authenticated")
     }
 
@@ -520,12 +495,8 @@ export async function deleteSetlist(id: string) {
 
     const supabase = getSupabaseBrowserClient()
 
-    // Check if user is authenticated
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
+    const user = getAuthenticatedUser()
+    if (!user) {
       throw new Error("User not authenticated")
     }
 
@@ -575,11 +546,8 @@ export async function addSongToSetlist(setlistId: string, contentId: string, pos
     const supabase = getSupabaseBrowserClient()
 
     // Check if user is authenticated
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
+    const user = getAuthenticatedUser()
+    if (!user) {
       throw new Error("User not authenticated")
     }
 
@@ -711,11 +679,8 @@ export async function removeSongFromSetlist(songId: string) {
     const supabase = getSupabaseBrowserClient()
 
     // Check if user is authenticated
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
+    const user = getAuthenticatedUser()
+    if (!user) {
       throw new Error("User not authenticated")
     }
 
@@ -803,12 +768,8 @@ export async function updateSongPosition(setlistId: string, songId: string, newP
 
     const supabase = getSupabaseBrowserClient()
 
-    // Check if user is authenticated
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser()
-    if (authError || !user) {
+    const user = getAuthenticatedUser()
+    if (!user) {
       throw new Error("User not authenticated")
     }
 


### PR DESCRIPTION
## Summary
- switch storage helpers to use Firebase auth
- refactor server utilities to read Firebase auth instead of Supabase
- update setlist service to rely on Firebase user
- clean up content service auth logic and creation flow
- adjust tests for new Firebase-based helpers

## Testing
- `pnpm lint`
- `pnpm test` *(fails: User not authenticated and Firebase Admin initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859cb6f850883299d220421402739d3