### PR TITLE
Refactor getServerSideUser to accept cookies

### DIFF
--- a/app/content/[id]/page.tsx
+++ b/app/content/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getServerSideUser } from "@/lib/firebase-server-utils";
+import { cookies } from "next/headers";
 import { getContentByIdServer } from "@/lib/content-service-server";
 import ContentPageClient from "@/components/content-page-client";
 
@@ -9,14 +10,15 @@ export default async function ContentPage({
   params: Promise<{ id: string }>;
 }) {
   // Check for Firebase authentication instead of Supabase
-  const user = await getServerSideUser();
+  const cookieStore = await cookies();
+  const user = await getServerSideUser(cookieStore);
   
   if (!user) {
     redirect("/login");
   }
 
   const resolvedParams = await params;
-  const content = await getContentByIdServer(resolvedParams.id);
+  const content = await getContentByIdServer(resolvedParams.id, cookieStore);
 
   return <ContentPageClient content={content} />;
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getServerSideUser } from "@/lib/firebase-server-utils";
+import { cookies } from "next/headers";
 import {
   getUserContentServer,
   getUserStatsServer,
@@ -9,16 +10,17 @@ import type { ContentItem } from "@/components/dashboard";
 
 export default async function DashboardPage() {
   // Check for Firebase authentication instead of Supabase
-  const user = await getServerSideUser()
+  const cookieStore = await cookies()
+  const user = await getServerSideUser(cookieStore)
   
   if (!user) {
     redirect("/login")
   }
 
   const [rawContentData, stats] = await Promise.all([
-    getUserContentServer(),
-    getUserStatsServer(),
-  ]);
+    getUserContentServer(cookieStore),
+    getUserStatsServer(cookieStore),
+  ])
   const contentData = rawContentData as ContentItem[];
 
   const sortedContent = [...contentData].sort(

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getServerSideUser } from "@/lib/firebase-server-utils";
+import { cookies } from "next/headers";
 import { getUserContentPageServer } from "@/lib/content-service-server";
 import LibraryPageClient from "@/components/library-page-client";
 
@@ -9,7 +10,8 @@ export default async function LibraryPage({
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }> 
 }) {
   // Check for Firebase authentication instead of Supabase
-  const user = await getServerSideUser();
+  const cookieStore = await cookies();
+  const user = await getServerSideUser(cookieStore);
   
   if (!user) {
     redirect("/login");
@@ -24,11 +26,14 @@ export default async function LibraryPage({
   const pageParam = resolvedSearchParams?.page;
   const page = pageParam ? parseInt(Array.isArray(pageParam) ? pageParam[0] : pageParam, 10) : 1;
   const pageSize = 20;
-  const { data, total } = await getUserContentPageServer({
-    page,
-    pageSize,
-    search,
-  });
+  const { data, total } = await getUserContentPageServer(
+    {
+      page,
+      pageSize,
+      search,
+    },
+    cookieStore
+  );
 
   return (
     <LibraryPageClient

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,11 +1,12 @@
 import Image from "next/image"
 import { redirect } from "next/navigation"
 import { getServerSideUser } from "@/lib/firebase-server-utils"
+import { cookies } from "next/headers"
 import { LoginPanel } from "@/components/auth/login-panel"
 import { Music } from "lucide-react"
 
 export default async function LoginPage({ searchParams }: { searchParams?: Promise<any> }) {
-  const user = await getServerSideUser()
+  const user = await getServerSideUser(await cookies())
 
   if (user) {
     redirect("/dashboard")

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,13 @@
 import { redirect } from "next/navigation"
 import { getServerSideUser } from "@/lib/firebase-server-utils"
+import { cookies } from "next/headers"
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
 import Link from "next/link"
 import { Music, FileText, Guitar, Users } from "lucide-react"
 
 export default async function LandingPage() {
-  const user = await getServerSideUser()
+  const user = await getServerSideUser(await cookies())
   if (user) {
     redirect("/dashboard")
   }

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getServerSideUser } from "@/lib/firebase-server-utils";
+import { cookies } from "next/headers";
 import {
   getContentByIdServer,
   getSetlistByIdServer,
@@ -8,7 +9,8 @@ import PerformancePageClient from "@/components/performance-page-client";
 
 export default async function PerformancePage({ searchParams }: { searchParams?: Promise<any> }) {
   // Check for Firebase authentication instead of Supabase
-  const user = await getServerSideUser();
+  const cookieStore = await cookies();
+  const user = await getServerSideUser(cookieStore);
   
   if (!user) {
     redirect("/login");
@@ -23,11 +25,11 @@ export default async function PerformancePage({ searchParams }: { searchParams?:
   let setlist: any | null = null;
 
   if (contentId) {
-    content = await getContentByIdServer(contentId);
+    content = await getContentByIdServer(contentId, cookieStore);
   }
 
   if (setlistId) {
-    setlist = await getSetlistByIdServer(setlistId);
+    setlist = await getSetlistByIdServer(setlistId, cookieStore);
   }
 
   return <PerformancePageClient content={content} setlist={setlist} startingSongIndex={startingSongIndex} />;

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,11 +1,12 @@
 import Image from "next/image"
 import { redirect } from "next/navigation"
 import { getServerSideUser } from "@/lib/firebase-server-utils"
+import { cookies } from "next/headers"
 import { SignupPanel } from "@/components/auth/signup-panel"
 import { Music } from "lucide-react"
 
 export default async function SignupPage() {
-  const user = await getServerSideUser()
+  const user = await getServerSideUser(await cookies())
 
   if (user) {
     redirect("/dashboard")

--- a/lib/__tests__/content-service-server.test.ts
+++ b/lib/__tests__/content-service-server.test.ts
@@ -12,7 +12,8 @@ describe('getUserContentServer', () => {
     vi.doMock('../supabase', () => ({ isSupabaseConfigured: true }))
     vi.doMock('../supabase-server', () => ({ getSupabaseServerClient: () => mockClient }))
     const { getUserContentServer } = await import('../content-service-server')
-    const res = await getUserContentServer()
+    const mockCookies = { get: vi.fn() } as any
+    const res = await getUserContentServer(mockCookies)
     expect(res).toEqual([])
     vi.resetModules()
     vi.doUnmock('../supabase')
@@ -29,7 +30,8 @@ describe('getContentByIdServer', () => {
     vi.doMock('../supabase', () => ({ isSupabaseConfigured: true }))
     vi.doMock('../supabase-server', () => ({ getSupabaseServerClient: () => mockClient }))
     const { getContentByIdServer } = await import('../content-service-server')
-    await expect(getContentByIdServer('1')).rejects.toThrow('User not authenticated')
+    const mockCookies = { get: vi.fn() } as any
+    await expect(getContentByIdServer('1', mockCookies)).rejects.toThrow('User not authenticated')
     vi.resetModules()
   })
 })

--- a/lib/content-service-server.ts
+++ b/lib/content-service-server.ts
@@ -1,6 +1,7 @@
 import { getSupabaseServerClient } from "@/lib/supabase-server";
 import { isSupabaseConfigured } from "@/lib/supabase";
 import { getServerSideUser } from "@/lib/firebase-server-utils";
+import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 import logger from "@/lib/logger";
 import {
   getUserContent,
@@ -11,9 +12,9 @@ import {
 import type { ContentQueryParams } from "@/lib/content-types";
 import { getSetlistById } from "@/lib/setlist-service";
 
-export async function getUserContentServer() {
+export async function getUserContentServer(cookieStore: ReadonlyRequestCookies) {
   // Check Firebase authentication first
-  const firebaseUser = await getServerSideUser();
+  const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
     // User is authenticated with Firebase, but we need to use Supabase for data
     if (!isSupabaseConfigured) {
@@ -36,9 +37,12 @@ export async function getUserContentServer() {
   return getUserContent(supabase);
 }
 
-export async function getUserContentPageServer(params: ContentQueryParams) {
+export async function getUserContentPageServer(
+  params: ContentQueryParams,
+  cookieStore: ReadonlyRequestCookies
+) {
   // Check Firebase authentication first
-  const firebaseUser = await getServerSideUser();
+  const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
     // User is authenticated with Firebase, but we need to use Supabase for data
     if (!isSupabaseConfigured) {
@@ -62,9 +66,12 @@ export async function getUserContentPageServer(params: ContentQueryParams) {
   return getUserContentPage(params, supabase);
 }
 
-export async function getContentByIdServer(id: string) {
+export async function getContentByIdServer(
+  id: string,
+  cookieStore: ReadonlyRequestCookies
+) {
   // Check Firebase authentication first
-  const firebaseUser = await getServerSideUser();
+  const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
     // User is authenticated with Firebase, but we need to use Supabase for data
     if (!isSupabaseConfigured) {
@@ -87,9 +94,9 @@ export async function getContentByIdServer(id: string) {
   return getContentById(id, supabase);
 }
 
-export async function getUserStatsServer() {
+export async function getUserStatsServer(cookieStore: ReadonlyRequestCookies) {
   // Check Firebase authentication first
-  const firebaseUser = await getServerSideUser();
+  const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
     // User is authenticated with Firebase, but we need to use Supabase for data
     if (!isSupabaseConfigured) {
@@ -112,12 +119,15 @@ export async function getUserStatsServer() {
   return getUserStats(supabase);
 }
 
-export async function getSetlistByIdServer(id: string) {
+export async function getSetlistByIdServer(
+  id: string,
+  cookieStore: ReadonlyRequestCookies
+) {
   if (!isSupabaseConfigured) {
     return getSetlistById(id);
   }
 
-  const firebaseUser = await getServerSideUser();
+  const firebaseUser = await getServerSideUser(cookieStore);
   if (!firebaseUser) {
     throw new Error("User not authenticated");
   }

--- a/lib/firebase-server-utils.ts
+++ b/lib/firebase-server-utils.ts
@@ -2,6 +2,7 @@
 // This file is safe to use in Edge Runtime as it doesn't import Firebase Admin directly
 
 import logger from './logger'
+import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies'
 
 export interface ServerAuthResult {
   isValid: boolean
@@ -126,16 +127,12 @@ export async function requireAuthServer(request: Request): Promise<{
   return validation.user
 }
 
-export async function getServerSideUser(): Promise<{
+export async function getServerSideUser(cookieStore: ReadonlyRequestCookies): Promise<{
   uid: string
   email?: string
   emailVerified?: boolean
 } | null> {
-  // In Next.js 13+ app router, we need to get the session cookie from headers or cookies
-  const { cookies } = await import('next/headers')
-  
   try {
-    const cookieStore = await cookies()
     const sessionCookie = cookieStore.get('firebase-session')
     
     if (!sessionCookie?.value) {


### PR DESCRIPTION
## Summary
- require a cookie store when fetching the server-side user
- thread the cookie context through server helpers and pages
- update tests for new function signature

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6859e98a27c88329a36db10aac825931