### PR TITLE
Support abort signals in content queries

### DIFF
--- a/components/library.tsx
+++ b/components/library.tsx
@@ -173,7 +173,7 @@ export function Library({
           search: debouncedSearch,
           sortBy,
           filters: selectedFilters,
-        }, undefined, { id: user.uid, email: user.email })
+        }, undefined, { id: user.uid, email: user.email }, controller.signal)
         
         if (fetchTimeoutId) {
           clearTimeout(fetchTimeoutId)
@@ -374,13 +374,14 @@ export function Library({
       } catch (err) {
         console.error('Failed to remove cached content', err)
       }
+      const controller = new AbortController()
       const { data, total } = await getUserContentPage({
         page,
         pageSize,
         search: searchQuery,
         sortBy,
         filters: selectedFilters,
-      }, undefined, { id: user.uid, email: user.email });
+      }, undefined, { id: user.uid, email: user.email }, controller.signal);
       setContent(data);
       setTotalCount(total);
       try {

--- a/lib/__tests__/search-array-fix.test.ts
+++ b/lib/__tests__/search-array-fix.test.ts
@@ -33,6 +33,7 @@ describe('Search Array Field Fix', () => {
             eq: vi.fn().mockReturnValue({
               or: vi.fn().mockReturnValue({
                 order: vi.fn().mockReturnValue({
+                  abortSignal: vi.fn().mockReturnThis(),
                   range: vi.fn().mockResolvedValue({
                     data: [],
                     error: null,
@@ -85,6 +86,7 @@ describe('Search Array Field Fix', () => {
             eq: vi.fn().mockReturnValue({
               or: vi.fn().mockReturnValue({
                 order: vi.fn().mockReturnValue({
+                  abortSignal: vi.fn().mockReturnThis(),
                   range: vi.fn().mockResolvedValue({
                     data: null,
                     error: { message: 'operator does not exist: text[] ~~* unknown' },
@@ -129,6 +131,7 @@ describe('Search Array Field Fix', () => {
             eq: vi.fn().mockReturnValue({
               or: vi.fn().mockReturnValue({
                 order: vi.fn().mockReturnValue({
+                  abortSignal: vi.fn().mockReturnThis(),
                   range: vi.fn().mockResolvedValue({
                     data: null,
                     error: { message: 'operator does not exist: text[] ~~* text' },
@@ -191,6 +194,7 @@ describe('Search Array Field Fix', () => {
             eq: vi.fn().mockReturnValue({
               or: vi.fn().mockReturnValue({
                 order: vi.fn().mockReturnValue({
+                  abortSignal: vi.fn().mockReturnThis(),
                   range: vi.fn().mockResolvedValue({
                     data: mockData,
                     error: null,

--- a/lib/content-service.ts
+++ b/lib/content-service.ts
@@ -138,7 +138,8 @@ if (typeof cleanupInterval.unref === 'function') {
 export async function getUserContentPage(
   params: ContentQueryParams = {},
   supabase?: SupabaseClient,
-  providedUser?: any
+  providedUser?: any,
+  signal?: AbortSignal
 ) {
   const {
     page = 1,
@@ -236,7 +237,7 @@ export async function getUserContentPage(
     const to = from + safePageSize - 1
 
     // Execute query with timeout
-    const queryPromise = query.range(from, to)
+    const queryPromise = query.abortSignal(signal).range(from, to)
     const timeoutPromise = new Promise((_, reject) =>
       setTimeout(() => reject(new Error('Database query timed out')), 15000)
     )


### PR DESCRIPTION
## Summary
- add `signal` parameter to `getUserContentPage`
- pass abort signals from Library component
- ensure Supabase queries handle abort signals
- update unit tests for abort signal support

## Testing
- `pnpm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a92389a188329965916d8286a3435