### PR TITLE
Remove demo mode references

### DIFF
--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -33,29 +33,6 @@ export async function POST(request: NextRequest): Promise<NextResponse<VerifyTok
       );
     }
 
-    // Handle demo mode (only in development)
-    if (token === 'demo-token' && process.env.NODE_ENV === 'development') {
-      return NextResponse.json({
-        success: true,
-        user: {
-          uid: 'demo-user',
-          email: 'demo@musicsheet.pro',
-          emailVerified: true,
-          displayName: 'Demo User'
-        }
-      });
-    }
-
-    // Reject demo token in production
-    if (token === 'demo-token') {
-      return NextResponse.json(
-        { 
-          success: false, 
-          error: 'Demo authentication not allowed in production' 
-        },
-        { status: 401 }
-      );
-    }
 
     // Verify the Firebase token
     const decodedToken = await verifyFirebaseToken(token);

--- a/components/auth/login-panel.tsx
+++ b/components/auth/login-panel.tsx
@@ -20,14 +20,14 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
   const [isLoading, setIsLoading] = useState(false)
   const [hasRedirected, setHasRedirected] = useState(false)
   const router = useRouter()
-  const { signIn, signInWithGoogle, signOut, isConfigured, user, profile, isInitialized } = useAuth()
+  const { signIn, signInWithGoogle, signOut, user, profile, isInitialized } = useAuth()
 
   useEffect(() => {
     if (isInitialized && user && !hasRedirected) {
       setHasRedirected(true)
       const handleRedirect = async () => {
-        // If we have a user but no profile and supabase is configured, create profile
-        if (isConfigured && !profile) {
+        // If we have a user but no profile, create profile
+        if (!profile) {
           try {
             const supabase = getSupabaseBrowserClient()
             await supabase.from("profiles").insert({
@@ -48,7 +48,7 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
       }
       handleRedirect()
     }
-  }, [user, profile, isInitialized, hasRedirected, isConfigured])
+  }, [user, profile, isInitialized, hasRedirected])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -56,11 +56,6 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
     setIsLoading(true)
 
     try {
-      if (!isConfigured) {
-        console.log("Demo mode - redirecting to dashboard")
-        window.location.href = "/dashboard"
-        return
-      }
 
       const { error: signInError } = await signIn(email, password)
       if (signInError) {
@@ -79,10 +74,6 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
     setError("")
     setIsLoading(true)
     try {
-      if (!isConfigured) {
-        window.location.href = "/dashboard"
-        return
-      }
 
       const { error: googleError } = await signInWithGoogle()
       if (googleError) {
@@ -144,7 +135,7 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
               <CardTitle className="text-xl text-amber-900">Sign In</CardTitle>
             </div>
             <CardDescription className="text-amber-700">
-              {!isConfigured ? "Demo mode - click Sign In to continue" : "Enter your credentials to access your music library"}
+              Enter your credentials to access your music library
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -158,12 +149,11 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
                   <Input
                     id="email"
                     placeholder="your.email@example.com"
-                    required={isConfigured}
+                    required
                     type="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     className="pl-10 bg-white border-amber-200 focus:border-amber-500 focus:ring-amber-500"
-                    disabled={!isConfigured}
                   />
                 </div>
               </div>
@@ -172,27 +162,24 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
                   <Label htmlFor="password" className="text-amber-800 font-medium">
                     Password
                   </Label>
-                  {isConfigured && (
-                    <button
-                      type="button"
-                      onClick={() => setError("Password reset not implemented in demo")}
-                      className="text-sm text-amber-600 hover:text-amber-800 hover:underline transition-colors"
-                    >
-                      Forgot password?
-                    </button>
-                  )}
+                  <button
+                    type="button"
+                    onClick={() => setError("Password reset not implemented yet")}
+                    className="text-sm text-amber-600 hover:text-amber-800 hover:underline transition-colors"
+                  >
+                    Forgot password?
+                  </button>
                 </div>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-amber-500 h-4 w-4" />
                   <Input
                     id="password"
                     placeholder="Enter your password"
-                    required={isConfigured}
+                    required
                     type="password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     className="pl-10 bg-white border-amber-200 focus:border-amber-500 focus:ring-amber-500"
-                    disabled={!isConfigured}
                   />
                 </div>
               </div>

--- a/components/setlist-manager.tsx
+++ b/components/setlist-manager.tsx
@@ -301,24 +301,6 @@ export function SetlistManager({ onEnterPerformance }: SetlistManagerProps) {
     }
   }, [loading, user, setlists.length, availableContent.length, loadData])
 
-  // Add a separate effect to check Supabase configuration
-  useEffect(() => {
-    const checkConfiguration = async () => {
-      try {
-        console.log("🔧 Checking Supabase configuration...")
-        const { isSupabaseConfigured } = await import("@/lib/supabase")
-        console.log("📊 Supabase configured:", isSupabaseConfigured)
-        
-        if (!isSupabaseConfigured) {
-          console.log("⚠️ Running in demo mode")
-        }
-      } catch (err) {
-        console.error("❌ Error checking configuration:", err)
-      }
-    }
-    
-    checkConfiguration()
-  }, [])
 
   const calculateTotalDuration = (songs: any[]) => {
     return songs.reduce((total, song) => {

--- a/contexts/__tests__/auth-context.test.tsx
+++ b/contexts/__tests__/auth-context.test.tsx
@@ -19,24 +19,6 @@ it('throws when useAuth is called outside provider', async () => {
 })
 
 describe('AuthProvider', () => {
-  it('initializes demo user when not configured', async () => {
-    vi.doMock('@/lib/supabase', () => ({
-      isSupabaseConfigured: false,
-      getSupabaseBrowserClient: vi.fn(),
-    }))
-    const mod = await import('../auth-context')
-    const wrapper = ({ children }: any) => <mod.AuthProvider>{children}</mod.AuthProvider>
-    const { result } = renderHook(() => mod.useAuth(), { wrapper })
-    await waitFor(() => result.current.isInitialized)
-    expect(result.current.isConfigured).toBe(false)
-    expect(result.current.user?.email).toBe('demo@musicsheet.pro')
-    let res: any
-    await act(async () => {
-      res = await result.current.signIn('a', 'b')
-    })
-    expect(res.error.message).toMatch(/Demo mode/)
-  })
-
   it('initializes with no session when configured', async () => {
     const getSession = vi.fn().mockResolvedValue({ data: { session: null }, error: null })
     const onAuthStateChange = vi.fn().mockImplementation((callback) => {
@@ -69,7 +51,6 @@ describe('AuthProvider', () => {
     // Wait for getSession to be called (it's called via getSessionSafe)
     await waitFor(() => expect(getSessionSafe).toHaveBeenCalled(), { timeout: 5000 })
     
-    expect(result.current.isConfigured).toBe(true)
     expect(result.current.user).toBe(null)
   })
 })

--- a/contexts/firebase-auth-context.tsx
+++ b/contexts/firebase-auth-context.tsx
@@ -108,36 +108,7 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
 
     const initializeAuth = async () => {
       try {
-        // If Firebase is not configured, set demo user and finish loading
         if (!isFirebaseConfigured || !auth) {
-          logger.log("Running in demo mode - Firebase not configured")
-          if (mounted) {
-            // Set a demo user for development
-            const demoUser = {
-              uid: "demo-user",
-              email: "demo@musicsheet.pro",
-              displayName: "Demo User",
-              emailVerified: true,
-            } as FirebaseUser
-
-            const demoProfile = {
-              id: "demo-user",
-              email: "demo@musicsheet.pro",
-              full_name: "Demo User",
-              first_name: "Demo",
-              last_name: "User",
-              avatar_url: null,
-              primary_instrument: "Guitar",
-              bio: "Demo user for MusicSheet Pro",
-              website: "https://musicsheet.pro",
-            }
-
-            setUser(demoUser)
-            setProfile(demoProfile)
-            setIdToken("demo-token")
-            setIsLoading(false)
-            setIsInitialized(true)
-          }
           return
         }
 
@@ -238,7 +209,7 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
   const signIn = useCallback(
     async (email: string, password: string) => {
       if (!isFirebaseConfigured || !auth) {
-        return { error: { message: "Demo mode - authentication disabled" } }
+        return { error: { message: "Authentication not configured" } }
       }
 
       try {
@@ -261,7 +232,7 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
 
   const signInWithGoogle = useCallback(async () => {
     if (!isFirebaseConfigured || !auth) {
-      return { error: { message: "Demo mode - authentication disabled" } }
+      return { error: { message: "Authentication not configured" } }
     }
 
     try {
@@ -284,7 +255,7 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
   const signUp = useCallback(
     async (email: string, password: string, userData: Partial<Profile>) => {
       if (!isFirebaseConfigured || !auth) {
-        return { error: { message: "Demo mode - authentication disabled" }, data: null }
+        return { error: { message: "Authentication not configured" }, data: null }
       }
 
       try {
@@ -376,8 +347,8 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
 
   const updateProfile = useCallback(
     async (data: Partial<Profile>) => {
-      if (!user || !isFirebaseConfigured || !idToken) {
-        return { error: new Error("Not authenticated or not configured") }
+      if (!user || !idToken) {
+        return { error: new Error("Not authenticated") }
       }
 
       try {
@@ -406,7 +377,7 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
         return { error }
       }
     },
-    [user, isFirebaseConfigured, idToken],
+    [user, idToken],
   )
 
   const value = {

--- a/lib/content-service-server.ts
+++ b/lib/content-service-server.ts
@@ -1,5 +1,4 @@
 import { getSupabaseServerClient } from "@/lib/supabase-server";
-import { isSupabaseConfigured } from "@/lib/supabase";
 import { getServerSideUser } from "@/lib/firebase-server-utils";
 import type { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 import logger from "@/lib/logger";
@@ -16,10 +15,6 @@ export async function getUserContentServer(cookieStore: ReadonlyRequestCookies) 
   // Check Firebase authentication first
   const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
-    // User is authenticated with Firebase, but we need to use Supabase for data
-    if (!isSupabaseConfigured) {
-      return getUserContent();
-    }
     const supabase = await getSupabaseServerClient();
     // Convert Firebase user to match Supabase format for content service
     const supabaseCompatibleUser = {
@@ -28,11 +23,7 @@ export async function getUserContentServer(cookieStore: ReadonlyRequestCookies) 
     };
     return getUserContent(supabase, supabaseCompatibleUser);
   }
-  
-  // Fallback to original Supabase authentication
-  if (!isSupabaseConfigured) {
-    return getUserContent();
-  }
+
   const supabase = await getSupabaseServerClient();
   return getUserContent(supabase);
 }
@@ -44,10 +35,6 @@ export async function getUserContentPageServer(
   // Check Firebase authentication first
   const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
-    // User is authenticated with Firebase, but we need to use Supabase for data
-    if (!isSupabaseConfigured) {
-      return getUserContentPage(params);
-    }
     const supabase = await getSupabaseServerClient();
     // Convert Firebase user to match Supabase format for content service
     const supabaseCompatibleUser = {
@@ -56,12 +43,7 @@ export async function getUserContentPageServer(
     };
     return getUserContentPage(params, supabase, supabaseCompatibleUser);
   }
-  
-  // Fallback to original Supabase authentication
-  if (!isSupabaseConfigured) {
-    // reuse browser implementation in demo mode
-    return getUserContentPage(params);
-  }
+
   const supabase = await getSupabaseServerClient();
   return getUserContentPage(params, supabase);
 }
@@ -74,9 +56,6 @@ export async function getContentByIdServer(
   const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
     // User is authenticated with Firebase, but we need to use Supabase for data
-    if (!isSupabaseConfigured) {
-      return getContentById(id);
-    }
     const supabase = await getSupabaseServerClient();
     // Convert Firebase user to match Supabase format for content service
     const supabaseCompatibleUser = {
@@ -85,11 +64,7 @@ export async function getContentByIdServer(
     };
     return getContentById(id, supabase, supabaseCompatibleUser);
   }
-  
-  // Fallback to original Supabase authentication
-  if (!isSupabaseConfigured) {
-    return getContentById(id);
-  }
+
   const supabase = await getSupabaseServerClient();
   return getContentById(id, supabase);
 }
@@ -98,10 +73,6 @@ export async function getUserStatsServer(cookieStore: ReadonlyRequestCookies) {
   // Check Firebase authentication first
   const firebaseUser = await getServerSideUser(cookieStore);
   if (firebaseUser) {
-    // User is authenticated with Firebase, but we need to use Supabase for data
-    if (!isSupabaseConfigured) {
-      return getUserStats();
-    }
     const supabase = await getSupabaseServerClient();
     // Convert Firebase user to match Supabase format for content service
     const supabaseCompatibleUser = {
@@ -110,11 +81,7 @@ export async function getUserStatsServer(cookieStore: ReadonlyRequestCookies) {
     };
     return getUserStats(supabase, supabaseCompatibleUser);
   }
-  
-  // Fallback to original Supabase authentication
-  if (!isSupabaseConfigured) {
-    return getUserStats();
-  }
+
   const supabase = await getSupabaseServerClient();
   return getUserStats(supabase);
 }
@@ -123,9 +90,6 @@ export async function getSetlistByIdServer(
   id: string,
   cookieStore: ReadonlyRequestCookies
 ) {
-  if (!isSupabaseConfigured) {
-    return getSetlistById(id);
-  }
 
   const firebaseUser = await getServerSideUser(cookieStore);
   if (!firebaseUser) {

--- a/lib/firebase-server-utils.ts
+++ b/lib/firebase-server-utils.ts
@@ -27,26 +27,6 @@ export async function validateFirebaseTokenServer(idToken: string): Promise<Serv
       }
     }
 
-    // Handle demo mode (only in development)
-    if (idToken === 'demo-token' && process.env.NODE_ENV === 'development') {
-      logger.warn('Using demo token in development mode')
-      return {
-        isValid: true,
-        user: {
-          uid: 'demo-user',
-          email: 'demo@musicsheet.pro',
-          emailVerified: true
-        }
-      }
-    }
-    
-    // Reject demo token in production
-    if (idToken === 'demo-token') {
-      return {
-        isValid: false,
-        error: 'Demo authentication not allowed in production'
-      }
-    }
 
     // For server-side usage, we need to construct the full URL. Vercel's
     // `VERCEL_URL` does not include a protocol, so we normalize it to ensure we

--- a/lib/storage-service.ts
+++ b/lib/storage-service.ts
@@ -1,12 +1,9 @@
-import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
+import { getSupabaseBrowserClient } from "@/lib/supabase"
 import { auth } from "@/lib/firebase"
 
 const BUCKET = process.env.NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET || "content-files"
 
 export async function testStoragePermissions(): Promise<{ canUpload: boolean; error?: string }> {
-  if (!isSupabaseConfigured) {
-    return { canUpload: true }; // Demo mode
-  }
 
   try {
     const supabase = getSupabaseBrowserClient();
@@ -67,12 +64,6 @@ export async function uploadFileToStorage(file: File | Blob, filename: string) {
   if (!file) throw new Error("No file provided")
   if (!filename) filename = `${Date.now()}`
 
-  if (!isSupabaseConfigured) {
-    console.log("Supabase not configured - using demo mode");
-    // Demo mode - pretend upload succeeded
-    const url = `https://example.com/${filename}`
-    return { url, path: filename }
-  }
 
   try {
     const supabase = getSupabaseBrowserClient()

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,96 +2,33 @@ import { createBrowserClient } from "@supabase/ssr"
 import logger from "@/lib/logger"
 import type { Database } from "@/types/supabase"
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
 export const isSupabaseConfigured = Boolean(
   supabaseUrl &&
-    supabaseAnonKey &&
-    supabaseUrl.startsWith("https://") &&
-    supabaseAnonKey.length > 20,
+  supabaseAnonKey &&
+  supabaseUrl.startsWith('https://') &&
+  supabaseAnonKey.length > 20,
 )
-
-const createMockClient = () => ({
-  auth: {
-    getSession: () =>
-      Promise.resolve({
-        data: { session: null },
-        error: null,
-      }),
-    onAuthStateChange: (callback: any) => {
-      setTimeout(() => callback("INITIAL_SESSION", null), 0)
-      return {
-        data: {
-          subscription: {
-            unsubscribe: () =>
-              logger.log("Mock auth subscription unsubscribed"),
-          },
-        },
-      }
-    },
-    signInWithPassword: () =>
-      Promise.resolve({
-        data: { user: null, session: null },
-        error: { message: "Demo mode - authentication disabled" },
-      }),
-    signUp: () =>
-      Promise.resolve({
-        data: { user: null, session: null },
-        error: { message: "Demo mode - authentication disabled" },
-      }),
-    signOut: () => Promise.resolve({ error: null }),
-    getUser: () =>
-      Promise.resolve({
-        data: { user: null },
-        error: null,
-      }),
-  },
-  from: () => ({
-    select: () => ({
-      eq: () => ({
-        single: () => Promise.resolve({ data: null, error: null }),
-        limit: () => Promise.resolve({ data: [], error: null }),
-      }),
-      limit: () => Promise.resolve({ data: [], error: null }),
-      order: () => Promise.resolve({ data: [], error: null }),
-    }),
-    insert: () => Promise.resolve({ data: null, error: null }),
-    update: () => ({
-      eq: () => Promise.resolve({ data: null, error: null }),
-    }),
-    delete: () => ({
-      eq: () => Promise.resolve({ data: null, error: null }),
-    }),
-  }),
-})
 
 let supabaseBrowserClient: ReturnType<typeof createBrowserClient> | null = null
 
 export function getSupabaseBrowserClient() {
   if (!supabaseBrowserClient) {
-    if (!isSupabaseConfigured) {
-      logger.warn("Supabase not configured - using mock client for demo mode")
-      supabaseBrowserClient = createMockClient() as any
-    } else {
-      supabaseBrowserClient = createBrowserClient<Database>(supabaseUrl!, supabaseAnonKey!, {
-        isSingleton: true,
-        auth: {
-          persistSession: true,
-          autoRefreshToken: true,
-        },
-      })
-    }
+    supabaseBrowserClient = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey, {
+      isSingleton: true,
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    })
   }
   return supabaseBrowserClient
 }
 
 // Test connection with comprehensive error handling
 export async function testSupabaseConnection(): Promise<boolean> {
-  if (!isSupabaseConfigured) {
-    return false
-  }
-
   try {
     const supabase = getSupabaseBrowserClient()
 


### PR DESCRIPTION
## Summary
- clean up login panel demo logic
- drop demo messages from setlist manager
- streamline auth contexts
- simplify Supabase client creation
- remove demo token handling in verify route
- drop demo checks from storage service

## Testing
- `pnpm test` *(fails: Firebase token verification failed, demo auth context tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf0bb09883299d2a9bdbb52c7183