### PR TITLE
Fix Firebase token validation in session route

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { validateFirebaseTokenServer } from '@/lib/firebase-server-utils'
+import { verifyFirebaseToken } from '@/lib/firebase-admin'
 import logger from '@/lib/logger'
 
 const SESSION_COOKIE_NAME = 'firebase-session'
@@ -17,10 +17,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Verify the token
-    const validation = await validateFirebaseTokenServer(idToken)
-    
-    if (!validation.isValid) {
+    // Verify the token using Firebase Admin directly
+    try {
+      await verifyFirebaseToken(idToken)
+    } catch (err) {
       return NextResponse.json(
         { error: 'Invalid token' },
         { status: 401 }


### PR DESCRIPTION
## Summary
- verify Google tokens with Firebase Admin directly when setting a session cookie

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685abc869ebc832993c9939394b3b2ad