### PR TITLE
Ensure session API runs in Node runtime

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyFirebaseToken } from '@/lib/firebase-admin'
 import logger from '@/lib/logger'
 
+export const runtime = 'nodejs' // Explicitly use Node.js runtime
+
 const SESSION_COOKIE_NAME = 'firebase-session'
 const SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 7 // 7 days
 


### PR DESCRIPTION
## Summary
- add Node.js runtime export to `app/api/auth/session/route.ts`

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685ac3dc17948329b10d2e91f714a5d3