### PR TITLE
Fix token verification URL building

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ The `ALLOWED_PROXY_HOSTS` variable controls which domains the
 offline cache proxy will fetch from. Add any additional hosts
 you need for external imports (comma‑separated).
 
+For server-side Firebase token validation, set `NEXTAUTH_URL` to your site's
+base URL (including `https://`). When deploying on Vercel you can rely on the
+`VERCEL_URL` environment variable instead. These values are used to construct
+the absolute URL for `/api/auth/verify`.
+
 ### First Steps
 1. **Import Content**: Start by uploading your existing sheet music and tabs
 2. **Create Setlists**: Organize songs for your upcoming performances

--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -30,7 +30,10 @@ describe('middleware auth', () => {
     const res = await middleware(req as any)
 
     expect(res.headers.get('location')).toBe('https://site.test/login')
-    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith('expired')
+    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith(
+      'expired',
+      baseReq.url
+    )
   })
 
   it('allows request when session cookie is valid', async () => {
@@ -48,7 +51,7 @@ describe('middleware auth', () => {
     const res = await middleware(req as any)
 
     expect(res.headers.get('location')).toBeNull()
-    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith('valid')
+    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith('valid', baseReq.url)
   })
 
   it('redirects to login when bearer token is invalid', async () => {
@@ -66,7 +69,10 @@ describe('middleware auth', () => {
     const res = await middleware(req as any)
 
     expect(res.headers.get('location')).toBe('https://site.test/login')
-    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith('badtoken')
+    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith(
+      'badtoken',
+      baseReq.url
+    )
   })
 
   it('allows request when bearer token is valid', async () => {
@@ -84,7 +90,10 @@ describe('middleware auth', () => {
     const res = await middleware(req as any)
 
     expect(res.headers.get('location')).toBeNull()
-    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith('goodtoken')
+    expect(mockValidateFirebaseTokenServer).toHaveBeenCalledWith(
+      'goodtoken',
+      baseReq.url
+    )
   })
 
   it('redirects to login when verification fails', async () => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -34,7 +34,7 @@ export async function middleware(request: NextRequest) {
   // Validate token using server-side utility
   if (token) {
     try {
-      const validation = await validateFirebaseTokenServer(token)
+      const validation = await validateFirebaseTokenServer(token, request.url)
       if (validation.isValid) {
         isAuthenticated = true
       }


### PR DESCRIPTION
## Summary
- ensure validateFirebaseTokenServer builds verification URL from env vars or request origin
- pass the request URL when validating tokens in middleware and API helpers
- warn when falling back to localhost
- document `NEXTAUTH_URL` and `VERCEL_URL` in README
- update tests for new validateFirebaseTokenServer signature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ac3dbffe0832994f74cbe06ec1035