### PR TITLE
Fix Next.js headers call

### DIFF
--- a/lib/firebase-server-utils.ts
+++ b/lib/firebase-server-utils.ts
@@ -142,7 +142,7 @@ export async function getServerSideUser(cookieStore: ReadonlyRequestCookies): Pr
     if (!origin) {
       try {
         const hdrs = (await import('next/headers')).headers
-        const host = hdrs().get('host')
+        const host = (await hdrs()).get('host')
         if (host) {
           const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http'
           origin = `${protocol}://${host}`


### PR DESCRIPTION
## Summary
- fix `headers` call in Firebase utils

## Testing
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm build` *(fails: Command failed)*

------
https://chatgpt.com/codex/tasks/task_e_685addfa40508329a1dce9467bdcd6c4