### PR TITLE
Implement functional password reset

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -9,6 +9,8 @@ import { Label } from "@/components/ui/label"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import Link from "next/link"
 import { ArrowLeft, Mail, CheckCircle } from "lucide-react"
+import { auth, isFirebaseConfigured } from "@/lib/firebase"
+import { sendPasswordResetEmail } from "firebase/auth"
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("")
@@ -21,12 +23,17 @@ export default function ForgotPasswordPage() {
     setError("")
     setIsLoading(true)
 
+    if (!isFirebaseConfigured || !auth) {
+      setError("Password reset is not available")
+      setIsLoading(false)
+      return
+    }
+
     try {
-      // Simulate password reset request
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+      await sendPasswordResetEmail(auth, email)
       setIsSubmitted(true)
     } catch (err: any) {
-      setError("Failed to send reset email. Please try again.")
+      setError(err?.message || "Failed to send reset email. Please try again.")
     } finally {
       setIsLoading(false)
     }

--- a/components/auth/login-panel.tsx
+++ b/components/auth/login-panel.tsx
@@ -244,13 +244,12 @@ export function LoginPanel({ initialError = "" }: { initialError?: string }) {
                   <Label htmlFor="password" className="text-amber-800 font-medium">
                     Password
                   </Label>
-                  <button
-                    type="button"
-                    onClick={() => setError("Password reset not implemented yet")}
+                  <Link
+                    href="/forgot-password"
                     className="text-sm text-amber-600 hover:text-amber-800 hover:underline transition-colors"
                   >
                     Forgot password?
-                  </button>
+                  </Link>
                 </div>
                 <div className="relative">
                   <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-amber-500 h-4 w-4" />

--- a/lib/__tests__/storage-service.test.ts
+++ b/lib/__tests__/storage-service.test.ts
@@ -12,11 +12,22 @@ it('uploads file when Supabase configured', async () => {
     getSupabaseBrowserClient: () => client
   }))
   vi.doMock('../firebase', () => ({
-    auth: { currentUser: { uid: 'user1', email: 'test@example.com' } }
+    auth: {
+      currentUser: {
+        uid: 'user1',
+        email: 'test@example.com',
+        getIdToken: vi.fn().mockResolvedValue('token')
+      }
+    }
   }))
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ url: 'https://bucket/test', path: 'test' })
+  })
   const { uploadFileToStorage } = await import('../storage-service')
   const res = await uploadFileToStorage(new Blob(['a']), 'test.pdf')
-  expect(upload).toHaveBeenCalled()
+  expect(fetch).toHaveBeenCalledWith('/api/storage/upload', expect.any(Object))
   expect(res.url).toBe('https://bucket/test')
+  vi.restoreAllMocks()
   vi.resetModules()
 })


### PR DESCRIPTION
## Summary
- swap text link for the forgot password action on the login panel
- implement real Firebase password reset using `sendPasswordResetEmail`
- adjust storage service unit test for new upload flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b36a06e7c8329beabb32c59f95585