### PR TITLE
Fix offline caching to use Firebase UID

### DIFF
--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -367,6 +367,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         await Promise.all([
           clearOfflineContent(uid),
           clearOfflineSetlists(uid),
+          clearOfflineContent('anon'),
+          clearOfflineSetlists('anon'),
         ])
       } catch (err) {
         console.warn("Failed to clear offline data:", err)

--- a/contexts/firebase-auth-context.tsx
+++ b/contexts/firebase-auth-context.tsx
@@ -365,6 +365,8 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
         await Promise.all([
           clearOfflineContent(uid),
           clearOfflineSetlists(uid),
+          clearOfflineContent('anon'),
+          clearOfflineSetlists('anon'),
         ])
       } catch (err) {
         logger.warn("Failed to clear offline data:", err)

--- a/lib/offline-cache.ts
+++ b/lib/offline-cache.ts
@@ -1,5 +1,5 @@
 import localforage from 'localforage'
-import { getSupabaseBrowserClient, getSessionSafe } from './supabase'
+import { auth } from './firebase'
 import { toast } from '@/hooks/use-toast'
 
 const FILE_PREFIX = 'octavia-offline-file'
@@ -21,9 +21,7 @@ function encodeBase64(data: Uint8Array): string {
 
 async function getUserId(): Promise<string | null> {
   try {
-    const supabase = getSupabaseBrowserClient()
-    const session = await getSessionSafe()
-    return session?.user?.id || null
+    return auth?.currentUser?.uid || null
   } catch {
     return null
   }

--- a/lib/offline-setlist-cache.ts
+++ b/lib/offline-setlist-cache.ts
@@ -1,13 +1,11 @@
 import localforage from 'localforage'
-import { getSupabaseBrowserClient, getSessionSafe } from './supabase'
+import { auth } from './firebase'
 
 const STORE_KEY_BASE = 'octavia-offline-setlists'
 
 async function getUserId(): Promise<string | null> {
   try {
-    const supabase = getSupabaseBrowserClient()
-    const session = await getSessionSafe()
-    return session?.user?.id || null
+    return auth?.currentUser?.uid || null
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- ensure offline caches use Firebase authentication
- remove Supabase dependencies from cache helpers
- clear both Firebase and anonymous offline data on logout

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685bfe85a2488329be58e01d20a407cc