### PR TITLE
Fix setlist and library queries to use Firebase UID

### DIFF
--- a/hooks/use-setlist-data.ts
+++ b/hooks/use-setlist-data.ts
@@ -53,9 +53,14 @@ export function useSetlistData(user: any | null, ready: boolean): UseSetlistData
         return
       }
 
+      const supabaseUser =
+        user && typeof (user as any).uid === "string"
+          ? { id: (user as any).uid, email: (user as any).email }
+          : undefined
+
       const [setsResult, contentResult] = await Promise.allSettled([
-        getUserSetlists(user),
-        getUserContent(undefined, user),
+        getUserSetlists(supabaseUser),
+        getUserContent(undefined, supabaseUser),
       ])
 
       const setsData =


### PR DESCRIPTION
## Summary
- ensure `useSetlistData` converts Firebase user to Supabase format

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685c3a13ab4c8329956ac8754a78da39