### PR TITLE
Update session cookie with refreshed token

### DIFF
--- a/contexts/firebase-auth-context.tsx
+++ b/contexts/firebase-auth-context.tsx
@@ -200,6 +200,7 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
             try {
               const token = await getIdToken(auth.currentUser, true)
               setIdToken(token)
+              await setSessionCookie(auth.currentUser)
             } catch (error) {
               logger.warn("Error refreshing token on visibility change:", error)
             }
@@ -215,6 +216,7 @@ export function FirebaseAuthProvider({ children }: { children: React.ReactNode }
             try {
               const token = await getIdToken(auth.currentUser, true)
               setIdToken(token)
+              await setSessionCookie(auth.currentUser)
             } catch (error) {
               logger.warn("Error during periodic token refresh:", error)
             }


### PR DESCRIPTION
## Summary
- refresh session cookie whenever auth token refreshes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c5b47906083298e4b908e1e0c843c