### PR TITLE
Fix middleware token validation

### DIFF
--- a/components/library.tsx
+++ b/components/library.tsx
@@ -437,7 +437,7 @@ export function Library({
             </PaginationItem>
             {Array.from({ length: Math.min(totalPages, 5) }).map((_, i) => {
               // Show first, last, and current page with 2 pages around current
-              let pageNum;
+              let pageNum: number;
               if (totalPages <= 5) {
                 pageNum = i + 1;
               } else if (page <= 3) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { validateFirebaseTokenServer } from '@/lib/firebase-server-utils'
 
-export const runtime = 'experimental-edge' // Use Edge Runtime for better performance
+export const runtime = 'nodejs'
 
 
 export async function middleware(request: NextRequest) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { validateFirebaseTokenServer } from '@/lib/firebase-server-utils'
 
-export const runtime = 'edge' // Use Edge Runtime for better performance
+export const runtime = 'experimental-edge' // Use Edge Runtime for better performance
 
 
 export async function middleware(request: NextRequest) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,30 +1,9 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
+import { validateFirebaseTokenServer } from '@/lib/firebase-server-utils'
 
 export const runtime = 'edge' // Use Edge Runtime for better performance
 
-// Simple token validation via API endpoint
-async function validateTokenViaAPI(token: string, baseUrl: string): Promise<boolean> {
-  try {
-    const response = await fetch(`${baseUrl}/api/auth/verify`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ token }),
-    })
-    
-    if (response.ok) {
-      const result = await response.json()
-      return result.success === true
-    }
-    
-    return false
-  } catch (error) {
-    console.error('Token validation failed in middleware:', error)
-    return false
-  }
-}
 
 export async function middleware(request: NextRequest) {
   const response = NextResponse.next({
@@ -55,11 +34,10 @@ export async function middleware(request: NextRequest) {
     token = firebaseSessionCookie
   }
 
-  // Validate token using API-based validation (Edge Runtime compatible)
+  // Validate token using server-side verification with caching
   if (token) {
     try {
-      const baseUrl = new URL(request.url).origin
-      isAuthenticated = await validateTokenViaAPI(token, baseUrl)
+      isAuthenticated = (await validateFirebaseTokenServer(token, request.url)).isValid;
       
       if (isAuthenticated) {
         console.log('Middleware: Token validation successful for', request.nextUrl.pathname)


### PR DESCRIPTION
## Summary
- remove API fetch token validation
- use `validateFirebaseTokenServer` in middleware

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685c71e7e6cc83298b0b62258c631f15