### PR TITLE
Fix remote image whitelist

### DIFF
--- a/IMAGE_OPTIMIZATION_SUMMARY.md
+++ b/IMAGE_OPTIMIZATION_SUMMARY.md
@@ -32,10 +32,21 @@ images: {
   deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
   imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   remotePatterns: [
-    {
-      protocol: 'https',
-      hostname: '**',
-    },
+    // Only allow images from your storage bucket and any
+    // additional hosts specified in ALLOWED_PROXY_HOSTS
+    ...(process.env.NEXT_PUBLIC_SUPABASE_URL
+      ? [
+          {
+            protocol: 'https',
+            hostname: new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname,
+          },
+        ]
+      : []),
+    ...((process.env.ALLOWED_PROXY_HOSTS || '')
+      .split(',')
+      .map(h => h.trim())
+      .filter(Boolean)
+      .map(hostname => ({ protocol: 'https', hostname }))),
   ],
 }
 ```

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,13 +18,22 @@ const nextConfig = {
     minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-    // Add any remote domains if needed in the future
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: '**',
-      },
-    ],
+    // Restrict optimized remote images to known hosts
+    remotePatterns: (() => {
+      const hosts = new Set()
+      const base = process.env.NEXT_PUBLIC_SUPABASE_URL
+      if (base) {
+        try {
+          hosts.add(new URL(base).hostname)
+        } catch {}
+      }
+      const extra = process.env.ALLOWED_PROXY_HOSTS?.split(',') || []
+      for (const h of extra) {
+        const host = h.trim()
+        if (host) hosts.add(host)
+      }
+      return Array.from(hosts).map(hostname => ({ protocol: 'https', hostname }))
+    })(),
   },
   webpack: (config, { isServer }) => {
     // Handle PDF.js worker


### PR DESCRIPTION
## Summary
- restrict remote image hosts in next.config
- document restricted domains for image optimization

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685e7aeddf10832998130b9d315fbbe1