### PR TITLE
Improve hybrid auth documentation and token cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,22 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET=content-files
+
+# Firebase Client configuration
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+
+# Firebase Admin credentials (server only)
+FIREBASE_PROJECT_ID=
+FIREBASE_CLIENT_EMAIL=
+FIREBASE_PRIVATE_KEY=""
+
+# Supabase service role key for server-side access
+SUPABASE_SERVICE_ROLE_KEY=
+
 # Allowed comma-separated hostnames for the /api/proxy endpoint
 ALLOWED_PROXY_HOSTS=demo.supabase.co,imslp.org,uploads.musescore.com

--- a/FIREBASE_SUPABASE_INTEGRATION.md
+++ b/FIREBASE_SUPABASE_INTEGRATION.md
@@ -77,6 +77,7 @@ NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET=content-files
 1. Keep your existing Supabase project
 2. Get the service role key from Settings → API
 3. Update database schema to use Firebase UIDs
+4. Run the policies in `supabase/rls-policies.sql` to enable row level security
 
 ### 3. Database Schema Updates
 
@@ -92,13 +93,12 @@ ALTER TABLE profiles
 ALTER TABLE content
   ADD COLUMN IF NOT EXISTS user_id TEXT REFERENCES profiles(id);
 
--- Disable RLS or update policies to work with service role
-ALTER TABLE profiles DISABLE ROW LEVEL SECURITY;
-ALTER TABLE content DISABLE ROW LEVEL SECURITY;
+-- Enable RLS and apply policies for Firebase UIDs
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE content ENABLE ROW LEVEL SECURITY;
 
--- Or create new RLS policies for service role access
-CREATE POLICY "Service role access" ON profiles
-  FOR ALL USING (auth.role() = 'service_role');
+-- Policies in supabase/rls-policies.sql restrict rows to the authenticated UID
+-- and still allow full access when using the service role key
 ```
 
 ## 🔐 Authentication Flow

--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ Automated unit tests live in `lib/__tests__` and are executed with [Vitest](http
 
 The application includes an offline mode backed by IndexedDB. A health check endpoint (`/api/health`) lets the client detect when connectivity returns. Library data and setlists viewed while online are cached locally so they can be accessed from the dedicated offline page when the network is unavailable. Cached files are stored as binary Blobs and an LRU policy keeps the total size under 50 MB to avoid quota errors.
 
+## 🔧 Configuration
+
+Create a `.env` file in the project root with the variables listed in `.env.example`. These include Firebase credentials and the Supabase service role key required for server-side database access.
+If you plan to enforce row level security, run the SQL in `supabase/rls-policies.sql` on your database.
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/lib/firebase-server-utils.ts
+++ b/lib/firebase-server-utils.ts
@@ -16,6 +16,17 @@ function isNodeJsRuntime(): boolean {
 // Cache verification results to avoid repeated validation and allow offline use
 const tokenCache = new Map<string, { result: ServerAuthResult; exp: number }>()
 
+// Periodically remove expired tokens to avoid unbounded memory usage
+const TOKEN_CACHE_CLEANUP_MS = 5 * 60 * 1000
+if (typeof setInterval === 'function') {
+  setInterval(() => {
+    const now = Date.now()
+    for (const [key, { exp }] of tokenCache) {
+      if (exp <= now) tokenCache.delete(key)
+    }
+  }, TOKEN_CACHE_CLEANUP_MS).unref?.()
+}
+
 export interface ServerAuthResult {
   isValid: boolean
   user?: {

--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -1,0 +1,15 @@
+-- Row level security policies for Firebase UID based access
+
+-- Profiles table
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "User owns profile" ON profiles
+  USING (id = auth.jwt()->> 'uid');
+CREATE POLICY "Service role access to profiles" ON profiles
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- Content table
+ALTER TABLE content ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "User owns content" ON content
+  USING (user_id = auth.jwt()->> 'uid');
+CREATE POLICY "Service role access to content" ON content
+  FOR ALL USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- document Firebase and Supabase environment variables
- add sample RLS policies for Supabase tables
- describe configuration steps in README and integration guide
- clean up expired tokens from the Firebase token cache

## Testing
- `pnpm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e7db7f45883299f1a2512d2d0ea97