### PR TITLE
Fix library load effect loop

### DIFF
--- a/hooks/use-library-data.ts
+++ b/hooks/use-library-data.ts
@@ -225,7 +225,7 @@ export function useLibraryData(options: Options): UseLibraryDataResult {
       inProgressRef.current = false
       setLoading(false)
     }
-  }, [user, page, pageSize, debouncedSearch, sortBy, selectedFilters, content.length])
+  }, [user, page, pageSize, debouncedSearch, sortBy, selectedFilters])
 
   useEffect(() => {
     if (ready) {


### PR DESCRIPTION
## Summary
- stabilize the `load` callback in `use-library-data`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643e3097188329a6e5ce2aec82e7bb