### PR TITLE
Disable console logs in production

### DIFF
--- a/app/api/storage/delete/route.ts
+++ b/app/api/storage/delete/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSupabaseServiceClient } from '@/lib/supabase-service'
 import { validateFirebaseTokenServer } from '@/lib/firebase-server-utils'
+import '@/lib/logger'
 
 const BUCKET = process.env.NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET || 'content-files'
 

--- a/app/api/storage/upload/route.ts
+++ b/app/api/storage/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSupabaseServiceClient } from '@/lib/supabase-service'
 import { validateFirebaseTokenServer } from '@/lib/firebase-server-utils'
+import '@/lib/logger'
 
 const BUCKET = process.env.NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET || 'content-files'
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react"
 import type { Metadata, Viewport } from "next"
 import "./globals.css"
+import "@/lib/logger"
 import { FirebaseAuthProvider } from "@/contexts/firebase-auth-context"
 import { SessionProvider } from "@/components/providers/session-provider"
 import { Toaster } from "@/components/ui/sonner"

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -1,5 +1,6 @@
 import * as admin from 'firebase-admin';
 import { getAuth } from 'firebase-admin/auth';
+import '@/lib/logger'
 
 // Helper function to properly format the private key
 function formatPrivateKey(privateKey: string): string {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,7 +1,20 @@
+const isProd = process.env.NODE_ENV === 'production'
+
+const noop = () => {}
+
+// Disable console logging in production to avoid leaking data and impacting performance
+if (isProd) {
+  // eslint-disable-next-line no-console
+  console.log = noop
+  // eslint-disable-next-line no-console
+  console.warn = noop
+}
+
 export const logger = {
-  log: (...args: unknown[]) => console.log(...args),
-  error: (...args: unknown[]) => console.error(...args),
-  warn: (...args: unknown[]) => console.warn(...args),
+  // Only log in non-production environments
+  log: (...args: unknown[]) => { if (!isProd) console.log(...args) },
+  error: (...args: unknown[]) => { if (!isProd) console.error(...args) },
+  warn: (...args: unknown[]) => { if (!isProd) console.warn(...args) },
 }
 
 export default logger

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { validateFirebaseTokenServer } from '@/lib/firebase-server-utils'
+import '@/lib/logger'
 
 export const runtime = 'nodejs'
 


### PR DESCRIPTION
## Summary
- disable console logging when NODE_ENV is production
- import logger early to trigger the override in server middleware and API routes

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6864534a8f4c8329a50c9df8e9f6a4cb