### PR TITLE
Enhance service worker handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 # next.js
 /.next/
 /out/
-fallback-*
+# allow service worker fallback script
+# fallback-* is generated at build time, but we keep the versioned file in repo
+!fallback-*.js
 
 # production
 /build

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { SessionProvider } from "@/components/providers/session-provider"
 import { Toaster } from "@/components/ui/sonner"
 import { EnhancedPwaInstallPrompt } from "@/components/pwa-install-prompt"
 import { ErrorBoundary } from "@/lib/error-boundary"
+import ServiceWorkerWrapper from "@/components/service-worker-wrapper"
 
 // Update app/layout.tsx metadata
 export const metadata: Metadata = {
@@ -38,6 +39,7 @@ export default function RootLayout({
             <SessionProvider>{children}</SessionProvider>
             <Toaster richColors position="top-right" />
             <EnhancedPwaInstallPrompt />
+            <ServiceWorkerWrapper />
           </FirebaseAuthProvider>
         </ErrorBoundary>
       </body>

--- a/components/service-worker-wrapper.tsx
+++ b/components/service-worker-wrapper.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import { useServiceWorker } from "@/hooks/use-service-worker"
+
+export default function ServiceWorkerWrapper() {
+  useServiceWorker()
+  return null
+}

--- a/hooks/use-service-worker.ts
+++ b/hooks/use-service-worker.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useEffect } from "react"
+import { Workbox } from "workbox-window"
+import { toast } from "@/hooks/use-toast"
+
+export function useServiceWorker() {
+  useEffect(() => {
+    if (typeof window === "undefined" || !("serviceWorker" in navigator)) return
+
+    const wb = new Workbox("/sw.js")
+
+    const handleWaiting = () => {
+      const t = toast({
+        title: "Update Available",
+        description: "A new version is ready.",
+        action: {
+          label: "Reload",
+          onClick: () => {
+            wb.addEventListener("controlling", () => {
+              window.location.reload()
+            })
+            wb.messageSkipWaiting()
+          },
+        },
+      })
+    }
+
+    wb.addEventListener("waiting", handleWaiting)
+
+    wb.register().catch(err => {
+      console.error("Service worker registration failed", err)
+    })
+  }, [])
+}

--- a/hooks/use-service-worker.tsx
+++ b/hooks/use-service-worker.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react"
 import { Workbox } from "workbox-window"
 import { toast } from "@/hooks/use-toast"
+import { ToastAction } from "@/components/ui/toast"
 
 export function useServiceWorker() {
   useEffect(() => {
@@ -11,18 +12,22 @@ export function useServiceWorker() {
     const wb = new Workbox("/sw.js")
 
     const handleWaiting = () => {
-      const t = toast({
+      toast({
         title: "Update Available",
         description: "A new version is ready.",
-        action: {
-          label: "Reload",
-          onClick: () => {
-            wb.addEventListener("controlling", () => {
-              window.location.reload()
-            })
-            wb.messageSkipWaiting()
-          },
-        },
+        action: (
+          <ToastAction
+            altText="Reload"
+            onClick={() => {
+              wb.addEventListener("controlling", () => {
+                window.location.reload()
+              })
+              wb.messageSkipWaiting()
+            }}
+          >
+            Reload
+          </ToastAction>
+        ),
       })
     }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,5 @@
 import withPWA from 'next-pwa'
-import runtimeCaching from 'next-pwa/cache.js'
+import runtimeCaching from './runtime-caching.js'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -143,7 +143,7 @@ const nextConfig = {
 const withPWANextConfig = withPWA({
   dest: 'public',
   runtimeCaching,
-  register: true,
+  register: false,
   skipWaiting: true,
   disable: process.env.NODE_ENV === 'development',
   fallbacks: {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "next": "15.2.4",
     "next-pwa": "^5.6.0",
     "next-themes": "^0.4.4",
+    "workbox-window": "^6.5.4",
     "pdfjs-dist": "4.8.69",
     "react": "^18",
     "react-day-picker": "8.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       vitest:
         specifier: latest
         version: 3.2.2(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.0.0)(@vitest/browser@3.2.2)(@vitest/ui@3.2.2)(happy-dom@17.6.3)(jiti@1.21.7)(jsdom@26.1.0(canvas@3.1.0))(msw@2.10.2(@types/node@22.0.0)(typescript@5.0.2))(terser@5.43.0)(yaml@2.8.0)
+      workbox-window:
+        specifier: ^6.5.4
+        version: 6.6.0
       zod:
         specifier: ^3.24.1
         version: 3.24.1

--- a/public/fallback-ZNhjLAtsITE_HWZT6QPEt.js
+++ b/public/fallback-ZNhjLAtsITE_HWZT6QPEt.js
@@ -1,0 +1,10 @@
+'use strict'
+
+self.fallback = async request => {
+  switch (request.destination) {
+    case 'document':
+      return caches.match('/_offline', { ignoreSearch: true })
+    default:
+      return Response.error()
+  }
+}

--- a/runtime-caching.js
+++ b/runtime-caching.js
@@ -1,0 +1,183 @@
+'use strict'
+
+// Workbox RuntimeCaching config: https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-build#.RuntimeCachingEntry
+module.exports = [
+  {
+    urlPattern: /^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,
+    handler: 'CacheFirst',
+    options: {
+      cacheName: 'google-fonts-webfonts',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 365 * 24 * 60 * 60 // 365 days
+      }
+    }
+  },
+  {
+    urlPattern: /^https:\/\/fonts\.(?:googleapis)\.com\/.*/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'google-fonts-stylesheets',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 7 * 24 * 60 * 60 // 7 days
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-font-assets',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 7 * 24 * 60 * 60 // 7 days
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-image-assets',
+      expiration: {
+        maxEntries: 64,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\/_next\/image\?url=.+$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'next-image',
+      expiration: {
+        maxEntries: 64,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:mp3|wav|ogg)$/i,
+    handler: 'CacheFirst',
+    options: {
+      rangeRequests: true,
+      cacheName: 'static-audio-assets',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:mp4)$/i,
+    handler: 'CacheFirst',
+    options: {
+      rangeRequests: true,
+      cacheName: 'static-video-assets',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:js)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-js-assets',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:css|less)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-style-assets',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\/_next\/data\/.+\/.+\.json$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'next-data',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:json|xml|csv)$/i,
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'static-data-assets',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: ({ url }) => {
+      const isSameOrigin = self.origin === url.origin
+      if (!isSameOrigin) return false
+      const pathname = url.pathname
+      // Exclude /api/auth/callback/* to fix OAuth workflow in Safari without impact other environment
+      // Above route is default for next-auth, you may need to change it if your OAuth workflow has a different callback route
+      // Issue: https://github.com/shadowwalker/next-pwa/issues/131#issuecomment-821894809
+      if (pathname.startsWith('/api/auth/')) return false
+      if (pathname.startsWith('/api/')) return true
+      return false
+    },
+    handler: 'NetworkFirst',
+    method: 'GET',
+    options: {
+      cacheName: 'apis',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      },
+      networkTimeoutSeconds: 10 // fall back to cache if api does not response within 10 seconds
+    }
+  },
+  {
+    urlPattern: ({ url }) => {
+      const isSameOrigin = self.origin === url.origin
+      if (!isSameOrigin) return false
+      const pathname = url.pathname
+      if (pathname.startsWith('/api/')) return false
+      return true
+    },
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'others',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      },
+      networkTimeoutSeconds: 10
+    }
+  },
+  {
+    urlPattern: ({ url }) => {
+      const isSameOrigin = self.origin === url.origin
+      return !isSameOrigin
+    },
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'cross-origin',
+      expiration: {
+        maxEntries: 32,
+        maxAgeSeconds: 15 * 60 // 15 minutes
+      },
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- customize runtime caching and disable auto SW register
- include hashed fallback script
- add Workbox-based SW registration with update prompt
- attach SW manager to root layout
- allow fallback file in repository

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686521b5f5e883298b27288d6aa44deb