### PR TITLE
Improve offline handling

### DIFF
--- a/app/_offline/page.tsx
+++ b/app/_offline/page.tsx
@@ -28,7 +28,7 @@ export default function OfflinePage() {
     try {
       if (navigator.onLine) {
         const response = await fetch('/api/health', {
-          method: 'HEAD',
+          method: 'GET',
           cache: 'no-cache'
         })
         if (response.ok) {

--- a/hooks/use-service-worker.tsx
+++ b/hooks/use-service-worker.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { Workbox } from "workbox-window"
 import { toast } from "@/hooks/use-toast"
 import { ToastAction } from "@/components/ui/toast"
+import { processQueue } from "@/lib/offline-queue"
 
 export function useServiceWorker() {
   useEffect(() => {
@@ -33,8 +34,13 @@ export function useServiceWorker() {
 
     wb.addEventListener("waiting", handleWaiting)
 
-    wb.register().catch(err => {
-      console.error("Service worker registration failed", err)
-    })
+    wb.register()
+      .then(() => {
+        wb.update()
+        processQueue()
+      })
+      .catch(err => {
+        console.error("Service worker registration failed", err)
+      })
   }, [])
 }

--- a/lib/content-service.ts
+++ b/lib/content-service.ts
@@ -3,6 +3,7 @@ import logger from "@/lib/logger";
 import type { Database } from "@/types/supabase";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { ContentQueryParams } from "./content-types";
+import { enqueueRequest } from "@/lib/offline-queue";
 
 type Content = Database["public"]["Tables"]["content"]["Row"];
 type ContentInsert = Database["public"]["Tables"]["content"]["Insert"];
@@ -555,6 +556,14 @@ export async function createContent(content: ContentInsert) {
     return await response.json();
   } catch (error) {
     logger.error("Error in createContent:", error);
+    if (typeof window !== "undefined" && !navigator.onLine) {
+      await enqueueRequest({
+        method: "POST",
+        url: "/api/content",
+        body: content,
+        headers: {},
+      });
+    }
     throw error;
   }
 }
@@ -631,6 +640,14 @@ export async function updateContent(id: string, content: ContentUpdate) {
     return data;
   } catch (error) {
     logger.error("Error in updateContent:", error);
+    if (typeof window !== "undefined" && !navigator.onLine) {
+      await enqueueRequest({
+        method: "PUT",
+        url: "/api/content",
+        body: { id, ...content },
+        headers: {},
+      });
+    }
     throw error;
   }
 }
@@ -697,6 +714,13 @@ export async function deleteContent(id: string) {
     return true;
   } catch (error) {
     logger.error("Error in deleteContent:", error);
+    if (typeof window !== "undefined" && !navigator.onLine) {
+      await enqueueRequest({
+        method: "DELETE",
+        url: `/api/content?id=${encodeURIComponent(id)}`,
+        headers: {},
+      });
+    }
     throw error;
   }
 }

--- a/lib/offline-queue.ts
+++ b/lib/offline-queue.ts
@@ -1,0 +1,44 @@
+import localforage from 'localforage'
+
+const QUEUE_KEY = 'octavia-offline-queue'
+
+export type QueueItem = {
+  method: 'POST' | 'PUT' | 'DELETE'
+  url: string
+  body?: any
+  headers?: Record<string, string>
+}
+
+export async function enqueueRequest(item: QueueItem): Promise<void> {
+  const queue = (await localforage.getItem<QueueItem[]>(QUEUE_KEY)) || []
+  queue.push(item)
+  await localforage.setItem(QUEUE_KEY, queue)
+}
+
+export async function processQueue(): Promise<void> {
+  const queue = (await localforage.getItem<QueueItem[]>(QUEUE_KEY)) || []
+  if (!queue.length) return
+  const remaining: QueueItem[] = []
+  for (const item of queue) {
+    try {
+      const res = await fetch(item.url, {
+        method: item.method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(item.headers || {}),
+        },
+        body: item.body ? JSON.stringify(item.body) : undefined,
+      })
+      if (!res.ok) throw new Error('request failed')
+    } catch {
+      remaining.push(item)
+    }
+  }
+  await localforage.setItem(QUEUE_KEY, remaining)
+}
+
+if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+  window.addEventListener('online', () => {
+    navigator.serviceWorker.ready.then(() => processQueue())
+  })
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -143,12 +143,16 @@ const nextConfig = {
 const withPWANextConfig = withPWA({
   dest: 'public',
   runtimeCaching,
-  register: false,
+  register: true,
   skipWaiting: true,
   disable: process.env.NODE_ENV === 'development',
   fallbacks: {
     document: '/_offline',
   },
+  additionalManifestEntries: [
+    { url: '/library', revision: null },
+    { url: '/performance', revision: null },
+  ],
 })(nextConfig)
 
 export default withPWANextConfig

--- a/runtime-caching.js
+++ b/runtime-caching.js
@@ -153,6 +153,26 @@ module.exports = [
       const isSameOrigin = self.origin === url.origin
       if (!isSameOrigin) return false
       const pathname = url.pathname
+      if (pathname.startsWith('/api/auth/')) return false
+      if (pathname.startsWith('/api/')) return true
+      return false
+    },
+    handler: 'NetworkFirst',
+    method: 'HEAD',
+    options: {
+      cacheName: 'api-head',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60
+      },
+      networkTimeoutSeconds: 10
+    }
+  },
+  {
+    urlPattern: ({ url }) => {
+      const isSameOrigin = self.origin === url.origin
+      if (!isSameOrigin) return false
+      const pathname = url.pathname
       if (pathname.startsWith('/api/')) return false
       return true
     },


### PR DESCRIPTION
## Summary
- add offline action queue using localforage
- queue POST/PUT/DELETE requests when offline
- process queue during SW registration and when connection returns
- cache HEAD requests in runtime caching
- enable automatic service worker registration and precache key routes
- switch offline page health check to GET

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865445e6e34832988cd1e6257f60a6b