### PR TITLE
Fix PWA precache exclusions

### DIFF
--- a/components/service-worker-wrapper.tsx
+++ b/components/service-worker-wrapper.tsx
@@ -14,6 +14,18 @@ export default function ServiceWorkerWrapper() {
       'serviceWorker' in navigator &&
       process.env.NODE_ENV === 'production'
     ) {
+      // Remove any leftover caches from old service workers
+      caches.keys().then(cacheNames => {
+        return Promise.all(
+          cacheNames.map(cacheName => {
+            if (cacheName.includes('precache')) {
+              return caches.delete(cacheName)
+            }
+            return Promise.resolve()
+          })
+        )
+      })
+
       // Listen for unhandled service worker errors (like precaching failures)
       window.addEventListener('unhandledrejection', (event) => {
         if (event.reason?.message?.includes('bad-precaching-response')) {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -154,20 +154,25 @@ const withPWANextConfig = withPWA({
     { url: '/performance', revision: null },
   ],
   // Exclude problematic files that cause 404 errors in production
-  exclude: [
+  buildExcludes: [
     // Default exclusions
     /\.map$/,
     /^manifest.*\.js$/,
-    // Additional exclusions to prevent 404 errors
+    // Additional exclusions to prevent caching internal Next.js manifests
+    /\/_next\/build-manifest\.json$/,
+    /\/_next\/react-loadable-manifest\.json$/,
+    /\/_next\/.*routes-manifest\.json$/,
+    /\/_next\/.*prerender-manifest\.json$/,
     /\/_next\/app-build-manifest\.json$/,
     /\/server\/middleware-build-manifest\.json$/,
     /\/_next\/static\/.*\/_buildManifest\.js$/,
     /\/_next\/static\/.*\/_ssgManifest\.js$/,
     // Exclude server-side files
-    ({ asset, compilation }) => {
+    ({ asset }) => {
       if (asset.name.includes('/server/')) return true;
       if (asset.name.includes('middleware-build-manifest')) return true;
       if (asset.name.includes('app-build-manifest')) return true;
+      if (asset.name.includes('client-reference-manifest')) return true;
       return false;
     },
   ],


### PR DESCRIPTION
## Summary
- exclude dynamic Next.js manifest files from the Workbox precache
- clean up leftover service worker caches on load

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686597bd32e08329a8eb4712329f67c9