### PR TITLE
Improve offline caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Automated unit tests live in `lib/__tests__` and are executed with [Vitest](http
 
 ### Offline Support
 
-The application includes an offline mode backed by IndexedDB. A health check endpoint (`/api/health`) lets the client detect when connectivity returns. Library data and setlists viewed while online are cached locally so they can be accessed from the dedicated offline page when the network is unavailable. Cached files are stored as binary Blobs and an LRU policy keeps the total size under 50 MB to avoid quota errors.
+The application includes an offline mode backed by IndexedDB. A health check endpoint (`/api/health`) lets the client detect when connectivity returns. Library data and setlists viewed while online are cached locally so they can be accessed from the dedicated offline page when the network is unavailable. Cached files are stored as binary Blobs and an LRU policy keeps the total size under 50 MB to avoid quota errors. In addition to IndexedDB, a custom service worker caches key pages and static assets so previously visited screens load even without a network connection.
 
 ## 🔧 Configuration
 

--- a/hooks/use-service-worker.tsx
+++ b/hooks/use-service-worker.tsx
@@ -60,6 +60,25 @@ export function useServiceWorker() {
           }
         })
 
+        navigator.serviceWorker.addEventListener("message", event => {
+          if (event.data?.type === "OFFLINE_FALLBACK") {
+            toast({
+              title: "Offline Mode",
+              description: "Showing cached content while offline.",
+              action: (
+                <ToastAction
+                  altText="Offline"
+                  onClick={() => {
+                    window.location.href = "/_offline"
+                  }}
+                >
+                  Offline Page
+                </ToastAction>
+              ),
+            })
+          }
+        })
+
         processQueue()
       })
       .catch(err => {

--- a/worker/index.js
+++ b/worker/index.js
@@ -3,6 +3,8 @@ console.log('Custom worker loaded');
 
 const CACHE_VERSION = 'v1';
 const CACHE_NAME = `octavia-${CACHE_VERSION}`;
+const STATIC_CACHE = `octavia-static-${CACHE_VERSION}`;
+const PAGE_CACHE = `octavia-pages-${CACHE_VERSION}`;
 const OFFLINE_URL = '/_offline';
 // Assets that should be available offline
 const ASSETS = [
@@ -51,7 +53,8 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(
     (async () => {
       const cacheNames = await caches.keys();
-      const oldCaches = cacheNames.filter(name => name !== CACHE_NAME);
+      const keep = [CACHE_NAME, STATIC_CACHE, PAGE_CACHE];
+      const oldCaches = cacheNames.filter(name => !keep.includes(name));
       await Promise.all(oldCaches.map(name => caches.delete(name)));
       console.log('Cleaned up old caches:', oldCaches);
       await self.clients.claim();
@@ -65,6 +68,7 @@ self.addEventListener('fetch', (event) => {
   if (request.method !== 'GET') return;
   const url = new URL(request.url);
 
+  // Cache-first for predefined assets
   if (ASSETS.includes(url.pathname)) {
     event.respondWith(
       caches.match(request).then(res => res || fetch(request))
@@ -72,9 +76,49 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // Cache static resources like JS, CSS and images from Next.js
+  if (url.origin === self.location.origin && (url.pathname.startsWith('/_next/static') || url.pathname.startsWith('/_next/image'))) {
+    event.respondWith(
+      (async () => {
+        const cache = await caches.open(STATIC_CACHE);
+        const cached = await cache.match(request);
+        if (cached) return cached;
+        try {
+          const res = await fetch(request);
+          cache.put(request, res.clone());
+          return res;
+        } catch {
+          return fetch(request);
+        }
+      })()
+    );
+    return;
+  }
+
+  // Network-first for navigation requests with offline fallback
   if (request.mode === 'navigate') {
     event.respondWith(
-      fetch(request).catch(() => caches.match(OFFLINE_URL))
+      (async () => {
+        try {
+          const res = await fetch(request);
+          const cache = await caches.open(PAGE_CACHE);
+          cache.put(request, res.clone());
+          return res;
+        } catch (err) {
+          const cache = await caches.open(PAGE_CACHE);
+          const cached = await cache.match(request);
+          if (cached) return cached;
+          const offline = await caches.match(OFFLINE_URL);
+          if (event.clientId) {
+            const client = await self.clients.get(event.clientId);
+            client?.postMessage({ type: 'OFFLINE_FALLBACK', url: request.url });
+          } else {
+            const clients = await self.clients.matchAll();
+            clients.forEach(c => c.postMessage({ type: 'OFFLINE_FALLBACK', url: request.url }));
+          }
+          return offline;
+        }
+      })()
     );
   }
 });


### PR DESCRIPTION
## Summary
- expand service worker caching to include static assets and pages
- notify clients when offline fallback is used
- display toast when offline fallback triggers
- document new service worker behavior in README

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6865bd94c1888329bd4c40e5a54f8844