### PR TITLE
Fix PDF viewer for sheet content

### DIFF
--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -44,7 +44,7 @@ import { deleteContent, clearContentCache } from "@/lib/content-service";
 import { MusicText } from "@/components/music-text";
 import Image from "next/image";
 import PdfViewer from "@/components/pdf-viewer";
-import { ContentType, getContentTypeIcon } from "@/types/content";
+import { ContentType, getContentTypeIcon, normalizeContentType } from "@/types/content";
 import { getContentTypeStyle } from "@/lib/content-type-styles";
 import { toast } from "sonner";
 
@@ -92,7 +92,8 @@ export function ContentViewer({
   const styles = getContentTypeStyle(content.content_type);
 
   const getHeaderGradient = (type: string) => {
-    switch (type) {
+    const t = normalizeContentType(type)
+    switch (t) {
       case ContentType.LYRICS:
         return "from-green-500 to-green-600";
       case ContentType.TAB:
@@ -332,7 +333,7 @@ export function ContentViewer({
                   {/* Content Based on Type */}
                   <div className="space-y-6">
                     {/* Sheet Music Content */}
-                    {content.content_type === ContentType.SHEET && (
+                    {normalizeContentType(content.content_type) === ContentType.SHEET && (
                       <div className="space-y-6">
                         <h3 className="text-lg font-semibold">Sheet Music</h3>
                         {/* Loading spinner while fetching offlineUrl */}
@@ -407,7 +408,7 @@ export function ContentViewer({
                     )}
 
                     {/* Guitar Tab Content */}
-                    {content.content_type === ContentType.TAB && (
+                    {normalizeContentType(content.content_type) === ContentType.TAB && (
                       <div className="space-y-6">
                         <h3 className="text-lg font-semibold">Tablature</h3>
                         {Array.isArray(content.content_data?.tablature) ? (
@@ -488,7 +489,7 @@ export function ContentViewer({
                     )}
 
                     {/* Chord Chart Content */}
-                    {content.content_type === ContentType.CHORDS && (
+                    {normalizeContentType(content.content_type) === ContentType.CHORDS && (
                       <div className="space-y-6">
                         <h3 className="text-lg font-semibold">
                           Chord Chart
@@ -591,7 +592,7 @@ export function ContentViewer({
                     )}
 
                     {/* Lyrics Content */}
-                    {content.content_type === ContentType.LYRICS && (
+                    {normalizeContentType(content.content_type) === ContentType.LYRICS && (
                       <div className="space-y-6">
                         <h3 className="text-lg font-semibold">Lyrics</h3>
 

--- a/components/editors/content-type-editor.tsx
+++ b/components/editors/content-type-editor.tsx
@@ -6,7 +6,7 @@ import { TabEditor } from "@/components/tab-editor"
 import { AnnotationTools } from "@/components/annotation-tools"
 import PdfViewer from "@/components/pdf-viewer"
 import Image from "next/image"
-import { ContentType } from "@/types/content"
+import { ContentType, normalizeContentType } from "@/types/content"
 
 interface ContentTypeEditorProps {
   content: any
@@ -24,7 +24,9 @@ export function ContentTypeEditor({ content, onChange }: ContentTypeEditorProps)
     })
   }
 
-  switch (content.content_type) {
+  const type = normalizeContentType(content.content_type)
+
+  switch (type) {
     case ContentType.CHORDS:
       return (
         <ChordEditor

--- a/components/performance-mode.tsx
+++ b/components/performance-mode.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { MusicText } from "@/components/music-text"
 import Image from "next/image"
 import PdfViewer from "@/components/pdf-viewer"
-import { ContentType } from "@/types/content"
+import { ContentType, normalizeContentType } from "@/types/content"
 import {
   X,
   ChevronLeft,
@@ -435,7 +435,7 @@ export function PerformanceMode({
                 maxWidth: zoom >= 100 ? `${10000 / zoom}%` : '100%'
               }}
             >
-              {currentSongData.content_type === ContentType.SHEET ? (
+              {normalizeContentType(currentSongData.content_type) === ContentType.SHEET ? (
                 sheetUrls[currentSong] ? (
                   (() => {
                     const url = sheetUrls[currentSong]!.toLowerCase()

--- a/lib/content-type-styles.ts
+++ b/lib/content-type-styles.ts
@@ -1,4 +1,4 @@
-import { ContentType } from "@/types/content"
+import { ContentType, normalizeContentType } from "@/types/content"
 
 export interface ContentTypeStyle {
   ring: string
@@ -8,7 +8,8 @@ export interface ContentTypeStyle {
 }
 
 export function getContentTypeStyle(type: string): ContentTypeStyle {
-  switch (type) {
+  const t = normalizeContentType(type)
+  switch (t) {
     case ContentType.LYRICS:
       return {
         ring: "ring-green-500",

--- a/types/content.ts
+++ b/types/content.ts
@@ -117,7 +117,7 @@ export function getContentTypeColors(contentType: ContentType | string) {
  * Normalize content type strings to ContentType enum values
  * Handles legacy formats like "Guitar Tab", "Chord Chart", etc.
  */
-function normalizeContentType(contentType: ContentType | string): ContentType {
+export function normalizeContentType(contentType: ContentType | string): ContentType {
   if (Object.values(ContentType).includes(contentType as ContentType)) {
     return contentType as ContentType
   }


### PR DESCRIPTION
## Summary
- normalize content type before comparing
- export `normalizeContentType` helper
- ensure sheet music PDFs render in viewer, editor and performance mode

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c1c26b4ac832986a9ad16bd2cfe8b