### PR TITLE
Fix PDF extension detection for signed URLs

### DIFF
--- a/components/content-viewer.tsx
+++ b/components/content-viewer.tsx
@@ -44,6 +44,7 @@ import { deleteContent, clearContentCache } from "@/lib/content-service";
 import { MusicText } from "@/components/music-text";
 import Image from "next/image";
 import PdfViewer from "@/components/pdf-viewer";
+import { urlHasExtension } from "@/lib/utils";
 import { ContentType, getContentTypeIcon, normalizeContentType } from "@/types/content";
 import { getContentTypeStyle } from "@/lib/content-type-styles";
 import { toast } from "sonner";
@@ -347,9 +348,11 @@ export function ContentViewer({
                             {(() => {
                               const url = offlineUrl || content.file_url;
                               if (!url) return null;
-                              const urlLower = url.toLowerCase();
-                              const isPdf = urlLower.endsWith(".pdf");
-                              const isImage = urlLower.endsWith(".png") || urlLower.endsWith(".jpg") || urlLower.endsWith(".jpeg");
+                              const isPdf = urlHasExtension(url, ".pdf");
+                              const isImage =
+                                urlHasExtension(url, ".png") ||
+                                urlHasExtension(url, ".jpg") ||
+                                urlHasExtension(url, ".jpeg");
                               if (isPdf) {
                                 return (
                                   <PdfViewer
@@ -376,9 +379,11 @@ export function ContentViewer({
                             {(() => {
                               const url = offlineUrl || content.file_url;
                               if (!url) return null;
-                              const urlLower = url.toLowerCase();
-                              const isPdf = urlLower.endsWith(".pdf");
-                              const isImage = urlLower.endsWith(".png") || urlLower.endsWith(".jpg") || urlLower.endsWith(".jpeg");
+                              const isPdf = urlHasExtension(url, ".pdf");
+                              const isImage =
+                                urlHasExtension(url, ".png") ||
+                                urlHasExtension(url, ".jpg") ||
+                                urlHasExtension(url, ".jpeg");
                               if ((offlineUrl || content.file_url) && !isPdf && !isImage) {
                                 return (
                                   <div className="text-center text-red-500 mt-4">Failed to load file. Please check the file format or try again later.</div>

--- a/components/editors/content-type-editor.tsx
+++ b/components/editors/content-type-editor.tsx
@@ -7,6 +7,7 @@ import { AnnotationTools } from "@/components/annotation-tools"
 import PdfViewer from "@/components/pdf-viewer"
 import Image from "next/image"
 import { ContentType, normalizeContentType } from "@/types/content"
+import { urlHasExtension } from "@/lib/utils"
 
 interface ContentTypeEditorProps {
   content: any
@@ -49,8 +50,8 @@ export function ContentTypeEditor({ content, onChange }: ContentTypeEditorProps)
       )
     case ContentType.SHEET:
       if (content.file_url) {
-        const url = content.file_url.toLowerCase()
-        if (url.endsWith(".pdf")) {
+        const url = content.file_url
+        if (urlHasExtension(url, ".pdf")) {
           return (
             <PdfViewer
               url={content.file_url}
@@ -59,7 +60,11 @@ export function ContentTypeEditor({ content, onChange }: ContentTypeEditorProps)
             />
           )
         }
-        if (url.endsWith(".png") || url.endsWith(".jpg") || url.endsWith(".jpeg")) {
+        if (
+          urlHasExtension(url, ".png") ||
+          urlHasExtension(url, ".jpg") ||
+          urlHasExtension(url, ".jpeg")
+        ) {
           return (
             <div className="flex justify-center">
               <Image

--- a/components/performance-mode.tsx
+++ b/components/performance-mode.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { MusicText } from "@/components/music-text"
 import Image from "next/image"
 import PdfViewer from "@/components/pdf-viewer"
+import { urlHasExtension } from "@/lib/utils"
 import { ContentType, normalizeContentType } from "@/types/content"
 import {
   X,
@@ -438,9 +439,12 @@ export function PerformanceMode({
               {normalizeContentType(currentSongData.content_type) === ContentType.SHEET ? (
                 sheetUrls[currentSong] ? (
                   (() => {
-                    const url = sheetUrls[currentSong]!.toLowerCase()
-                    const isPdf = url.endsWith(".pdf")
-                    const isImage = url.endsWith(".png") || url.endsWith(".jpg") || url.endsWith(".jpeg")
+                    const url = sheetUrls[currentSong]!
+                    const isPdf = urlHasExtension(url, ".pdf")
+                    const isImage =
+                      urlHasExtension(url, ".png") ||
+                      urlHasExtension(url, ".jpg") ||
+                      urlHasExtension(url, ".jpeg")
                     if (isPdf) {
                       return (
                         <div>

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { cn } from '../utils'
+import { cn, urlHasExtension } from '../utils'
 
 describe('cn', () => {
   it('merges class names correctly', () => {
@@ -8,5 +8,13 @@ describe('cn', () => {
     expect(cn('foo', undefined, 'bar')).toBe('foo bar')
     expect(cn('foo', 'foo', 'bar')).toBe('foo foo bar')
     expect(cn('px-2', 'px-4')).toBe('px-4')
+  })
+})
+
+describe('urlHasExtension', () => {
+  it('detects extension before query or hash', () => {
+    expect(urlHasExtension('https://x.com/file.pdf?token=123', '.pdf')).toBe(true)
+    expect(urlHasExtension('https://x.com/file.png#section', '.png')).toBe(true)
+    expect(urlHasExtension('https://x.com/file.jpeg', '.jpg')).toBe(false)
   })
 })

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function urlHasExtension(url: string, ext: string): boolean {
+  const clean = url.split('?')[0].split('#')[0]
+  return clean.toLowerCase().endsWith(ext.toLowerCase())
+}


### PR DESCRIPTION
## Summary
- add `urlHasExtension` util that ignores query strings
- use the util in viewer and editor components
- test `urlHasExtension`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686c320b86a483299e72bbb6fb7c6520